### PR TITLE
cage: optionally return exitcode of primary client

### DIFF
--- a/cage.1.scd
+++ b/cage.1.scd
@@ -6,7 +6,7 @@ cage - a Wayland kiosk compositor
 
 # SYNOPSIS
 
-*cage* [-dhmrsv] [--] _application_ [application argument ...]
+*cage* [-dehmrsv] [--] _application_ [application argument ...]
 
 # DESCRIPTION
 
@@ -18,6 +18,10 @@ activities outside the scope of the running application are prevented.
 
 *-d*
 	Don't draw client side decorations when possible.
+
+*-e*
+	Return the primary client's exit code if Cage shuts down because of the
+	client exiting.
 
 *-h*
 	Show the help message.

--- a/server.h
+++ b/server.h
@@ -51,6 +51,7 @@ struct cg_server {
 #ifdef DEBUG
 	bool debug_damage_tracking;
 #endif
+    bool return_app_code;
 };
 
 #endif


### PR DESCRIPTION
Some applications indicate different shutdown conditions by returning
specific exit codes. One of these is e.g. Kodi, which returns 64 in case
the user chose "Power off" and 66 in case the user chose "Reboot".
In order to act on these exit codes, it thus makes sense in some
situations to pass them on from the primary client to the caller of
Cage.

Add a new flag "-e". If it's set and Cage shutso down because of an
orderly exit of its primary client, then it causes Cage to return the
primary client's exit code instead of its own one.