### PR TITLE
Add basic wlr-output-management support 

### DIFF
--- a/cage.1.scd
+++ b/cage.1.scd
@@ -27,10 +27,6 @@ activities outside the scope of the running application are prevented.
 	*last* Cage uses only the last connected monitor.
 	*extend* Cage extends the display across all connected monitors.
 
-*-r*
-	Rotate the output 90 degrees clockwise. This can be specified up to three
-	times, each resulting in an additional 90 degrees clockwise rotation.
-
 *-s*
 	Allow VT switching
 

--- a/cage.c
+++ b/cage.c
@@ -28,6 +28,7 @@
 #include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_presentation_time.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_screencopy_v1.h>
@@ -340,6 +341,8 @@ main(int argc, char *argv[])
 		ret = 1;
 		goto end;
 	}
+	server.output_layout_change.notify = handle_output_layout_change;
+	wl_signal_add(&server.output_layout->events.change, &server.output_layout_change);
 
 	server.scene = wlr_scene_create();
 	if (!server.scene) {
@@ -471,6 +474,17 @@ main(int argc, char *argv[])
 		ret = 1;
 		goto end;
 	}
+
+	server.output_manager_v1 = wlr_output_manager_v1_create(server.wl_display);
+	if (!server.output_manager_v1) {
+		wlr_log(WLR_ERROR, "Unable to create the output manager");
+		ret = 1;
+		goto end;
+	}
+	server.output_manager_apply.notify = handle_output_manager_apply;
+	wl_signal_add(&server.output_manager_v1->events.apply, &server.output_manager_apply);
+	server.output_manager_test.notify = handle_output_manager_test;
+	wl_signal_add(&server.output_manager_v1->events.test, &server.output_manager_test);
 
 	gamma_control_manager = wlr_gamma_control_manager_v1_create(server.wl_display);
 	if (!gamma_control_manager) {

--- a/cage.c
+++ b/cage.c
@@ -201,7 +201,6 @@ usage(FILE *file, const char *cage)
 		" -h\t Display this help message\n"
 		" -m extend Extend the display across all connected outputs (default)\n"
 		" -m last Use only the last connected output\n"
-		" -r\t Rotate the output 90 degrees clockwise, specify up to three times\n"
 		" -s\t Allow VT switching\n"
 		" -v\t Show the version number and exit\n"
 		"\n"
@@ -213,7 +212,7 @@ static bool
 parse_args(struct cg_server *server, int argc, char *argv[])
 {
 	int c;
-	while ((c = getopt(argc, argv, "dhm:rsv")) != -1) {
+	while ((c = getopt(argc, argv, "dhm:sv")) != -1) {
 		switch (c) {
 		case 'd':
 			server->xdg_decoration = true;
@@ -226,12 +225,6 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 				server->output_mode = CAGE_MULTI_OUTPUT_MODE_LAST;
 			} else if (strcmp(optarg, "extend") == 0) {
 				server->output_mode = CAGE_MULTI_OUTPUT_MODE_EXTEND;
-			}
-			break;
-		case 'r':
-			server->output_transform++;
-			if (server->output_transform > WL_OUTPUT_TRANSFORM_270) {
-				server->output_transform = WL_OUTPUT_TRANSFORM_NORMAL;
 			}
 			break;
 		case 's':

--- a/output.c
+++ b/output.c
@@ -225,12 +225,10 @@ output_destroy(struct cg_output *output)
 
 	if (wl_list_empty(&server->outputs)) {
 		wl_display_terminate(server->wl_display);
-	} else if (server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST) {
+	} else if (server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST && !wl_list_empty(&server->outputs)) {
 		struct cg_output *prev = wl_container_of(server->outputs.next, prev, link);
-		if (prev) {
-			output_enable(prev);
-			view_position_all(server);
-		}
+		output_enable(prev);
+		view_position_all(server);
 	}
 }
 
@@ -293,11 +291,9 @@ handle_new_output(struct wl_listener *listener, void *data)
 		}
 	}
 
-	if (server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST) {
+	if (server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST && wl_list_length(&server->outputs) > 1) {
 		struct cg_output *next = wl_container_of(output->link.next, next, link);
-		if (next) {
-			output_disable(next);
-		}
+		output_disable(next);
 	}
 
 	if (!wlr_xcursor_manager_load(server->seat->xcursor_manager, wlr_output->scale)) {

--- a/output.c
+++ b/output.c
@@ -217,8 +217,6 @@ handle_new_output(struct wl_listener *listener, void *data)
 		}
 	}
 
-	wlr_output_set_transform(wlr_output, output->server->output_transform);
-
 	if (server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST) {
 		struct cg_output *next = wl_container_of(output->link.next, next, link);
 		if (next) {

--- a/output.h
+++ b/output.h
@@ -21,6 +21,9 @@ struct cg_output {
 	struct wl_list link; // cg_server::outputs
 };
 
+void handle_output_manager_apply(struct wl_listener *listener, void *data);
+void handle_output_manager_test(struct wl_listener *listener, void *data);
+void handle_output_layout_change(struct wl_listener *listener, void *data);
 void handle_new_output(struct wl_listener *listener, void *data);
 void output_set_window_title(struct cg_output *output, const char *title);
 

--- a/server.h
+++ b/server.h
@@ -37,6 +37,7 @@ struct cg_server {
 	 * some outputs may be disabled. */
 	struct wl_list outputs; // cg_output::link
 	struct wl_listener new_output;
+	struct wl_listener output_layout_change;
 
 	struct wl_listener xdg_toplevel_decoration;
 	struct wl_listener new_xdg_shell_surface;
@@ -46,6 +47,9 @@ struct cg_server {
 #if CAGE_HAS_XWAYLAND
 	struct wl_listener new_xwayland_surface;
 #endif
+	struct wlr_output_manager_v1 *output_manager_v1;
+	struct wl_listener output_manager_apply;
+	struct wl_listener output_manager_test;
 
 	bool xdg_decoration;
 	bool allow_vt_switch;

--- a/server.h
+++ b/server.h
@@ -49,7 +49,6 @@ struct cg_server {
 
 	bool xdg_decoration;
 	bool allow_vt_switch;
-	enum wl_output_transform output_transform;
 };
 
 #endif

--- a/view.c
+++ b/view.c
@@ -98,6 +98,15 @@ view_position(struct cg_view *view)
 }
 
 void
+view_position_all(struct cg_server *server)
+{
+	struct cg_view *view;
+	wl_list_for_each (view, &server->views, link) {
+		view_position(view);
+	}
+}
+
+void
 view_unmap(struct cg_view *view)
 {
 	wl_list_remove(&view->link);

--- a/view.h
+++ b/view.h
@@ -49,6 +49,7 @@ bool view_is_primary(struct cg_view *view);
 bool view_is_transient_for(struct cg_view *child, struct cg_view *parent);
 void view_activate(struct cg_view *view, bool activate);
 void view_position(struct cg_view *view);
+void view_position_all(struct cg_server *server);
 void view_unmap(struct cg_view *view);
 void view_map(struct cg_view *view, struct wlr_surface *surface);
 void view_destroy(struct cg_view *view);


### PR DESCRIPTION
I have tried to resume work from @dimkr in PR #213.
- Rebased on current HEAD
- Implements output manager test (`wlr-randr --dryrun`)
- Add output layout change monitor to ensure views are well positioned according to new layout

For the moment, I have only played with Wayland as backend.
I am still unsure about `current_mode` test, see [discussion](https://github.com/cage-kiosk/cage/pull/213#discussion_r1267768236).
Furthermore, trying to disable an output returns an error. I don't know if it specific to Wayland backend. Here are the logs from wlroots (0.16.2):
```
00:00:04.247 [types/output/output.c:656] Tried to modeset a disabled output
00:00:04.247 [types/output/output.c:734] Basic output test failed for WL-2
```
