### PR TITLE
seat: add missing touch_frame handler

### DIFF
--- a/seat.c
+++ b/seat.c
@@ -566,6 +566,15 @@ handle_touch_motion(struct wl_listener *listener, void *data)
 }
 
 static void
+handle_touch_frame(struct wl_listener *listener, void *data)
+{
+	struct cg_seat *seat = wl_container_of(listener, seat, touch_frame);
+
+	wlr_seat_touch_notify_frame(seat->seat);
+	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+}
+
+static void
 handle_cursor_frame(struct wl_listener *listener, void *data)
 {
 	struct cg_seat *seat = wl_container_of(listener, seat, cursor_frame);
@@ -748,6 +757,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&seat->touch_down.link);
 	wl_list_remove(&seat->touch_up.link);
 	wl_list_remove(&seat->touch_motion.link);
+	wl_list_remove(&seat->touch_frame.link);
 	wl_list_remove(&seat->request_set_cursor.link);
 	wl_list_remove(&seat->request_set_selection.link);
 	wl_list_remove(&seat->request_set_primary_selection.link);
@@ -830,6 +840,8 @@ seat_create(struct cg_server *server, struct wlr_backend *backend)
 	wl_signal_add(&seat->cursor->events.touch_up, &seat->touch_up);
 	seat->touch_motion.notify = handle_touch_motion;
 	wl_signal_add(&seat->cursor->events.touch_motion, &seat->touch_motion);
+	seat->touch_frame.notify = handle_touch_frame;
+	wl_signal_add(&seat->cursor->events.touch_frame, &seat->touch_frame);
 
 	seat->request_set_cursor.notify = handle_request_set_cursor;
 	wl_signal_add(&seat->seat->events.request_set_cursor, &seat->request_set_cursor);

--- a/seat.h
+++ b/seat.h
@@ -39,6 +39,7 @@ struct cg_seat {
 	struct wl_listener touch_down;
 	struct wl_listener touch_up;
 	struct wl_listener touch_motion;
+	struct wl_listener touch_frame;
 
 	struct wl_list drag_icons;
 	struct wl_listener request_start_drag;


### PR DESCRIPTION
wl_touch::frame() is expected to be sent to client to indicate end of touch frame event and not sending it may causes issues. For example, Qt applications using Qt Wayland platform plugin do not consider touch events until this end of frame event to be received.