### PR TITLE
output: do not always terminate when last output is destroyed

### DIFF
--- a/output.c
+++ b/output.c
@@ -287,6 +287,9 @@ handle_new_output(struct wl_listener *listener, void *data)
 	wl_signal_add(&wlr_output->events.frame, &output->frame);
 
 	if (!wl_list_empty(&wlr_output->modes)) {
+		/* Ensure the output is marked as enabled before trying to set mode */
+		wlr_output_enable(wlr_output, true);
+
 		struct wlr_output_mode *preferred_mode = wlr_output_preferred_mode(wlr_output);
 		if (preferred_mode) {
 			wlr_output_set_mode(wlr_output, preferred_mode);


### PR DESCRIPTION
Only terminate if the last output was nested under the Wayland or X11 backend. If not, using DRM backend for example, terminating Cage when unplugging the last monitor or simply turning it off does not seem to be the right behavior.

Proposed as a draft for now.
It addresses issue #208 .