### PR TITLE
Fix initial position of X11 override-redirects

### DIFF
--- a/view.c
+++ b/view.c
@@ -90,6 +90,13 @@ view_position(struct cg_view *view)
 	struct wlr_box layout_box;
 	wlr_output_layout_get_box(view->server->output_layout, NULL, &layout_box);
 
+#if CAGE_HAS_XWAYLAND
+	/* We shouldn't position override-redirect windows. They set
+	   their own (x,y) coordinates in handle_xwayland_surface_set_geometry. */
+	if (view->type == CAGE_XWAYLAND_VIEW && !xwayland_view_should_manage(view)) {
+		wlr_scene_node_set_position(&view->scene_tree->node, view->lx, view->ly);
+	} else
+#endif
 	if (view_is_primary(view) || view_extends_output_layout(view, &layout_box)) {
 		view_maximize(view, &layout_box);
 	} else {
@@ -130,14 +137,7 @@ view_map(struct cg_view *view, struct wlr_surface *surface)
 	view->wlr_surface = surface;
 	surface->data = view;
 
-#if CAGE_HAS_XWAYLAND
-	/* We shouldn't position override-redirect windows. They set
-	   their own (x,y) coordinates in handle_wayland_surface_map. */
-	if (view->type != CAGE_XWAYLAND_VIEW || xwayland_view_should_manage(view))
-#endif
-	{
-		view_position(view);
-	}
+	view_position(view);
 
 	wl_list_insert(&view->server->views, &view->link);
 	seat_set_focus(view->server->seat, view);

--- a/xwayland.c
+++ b/xwayland.c
@@ -104,6 +104,18 @@ handle_xwayland_surface_request_fullscreen(struct wl_listener *listener, void *d
 }
 
 static void
+handle_xwayland_surface_set_geometry(struct wl_listener *listener, void *data)
+{
+	struct cg_xwayland_view *xwayland_view = wl_container_of(listener, xwayland_view, set_geometry);
+	struct cg_view *view = &xwayland_view->view;
+
+	if (!xwayland_view_should_manage(view)) {
+		view->lx = xwayland_view->xwayland_surface->x;
+		view->ly = xwayland_view->xwayland_surface->y;
+	}
+}
+
+static void
 handle_xwayland_surface_unmap(struct wl_listener *listener, void *data)
 {
 	struct cg_xwayland_view *xwayland_view = wl_container_of(listener, xwayland_view, unmap);
@@ -118,11 +130,6 @@ handle_xwayland_surface_map(struct wl_listener *listener, void *data)
 	struct cg_xwayland_view *xwayland_view = wl_container_of(listener, xwayland_view, map);
 	struct cg_view *view = &xwayland_view->view;
 
-	if (!xwayland_view_should_manage(view)) {
-		view->lx = xwayland_view->xwayland_surface->x;
-		view->ly = xwayland_view->xwayland_surface->y;
-	}
-
 	view_map(view, xwayland_view->xwayland_surface->surface);
 }
 
@@ -136,6 +143,7 @@ handle_xwayland_surface_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&xwayland_view->unmap.link);
 	wl_list_remove(&xwayland_view->destroy.link);
 	wl_list_remove(&xwayland_view->request_fullscreen.link);
+	wl_list_remove(&xwayland_view->set_geometry.link);
 	xwayland_view->xwayland_surface = NULL;
 
 	view_destroy(view);
@@ -174,4 +182,6 @@ handle_xwayland_surface_new(struct wl_listener *listener, void *data)
 	wl_signal_add(&xwayland_surface->events.destroy, &xwayland_view->destroy);
 	xwayland_view->request_fullscreen.notify = handle_xwayland_surface_request_fullscreen;
 	wl_signal_add(&xwayland_surface->events.request_fullscreen, &xwayland_view->request_fullscreen);
+	xwayland_view->set_geometry.notify = handle_xwayland_surface_set_geometry;
+	wl_signal_add(&xwayland_surface->events.set_geometry, &xwayland_view->set_geometry);
 }

--- a/xwayland.h
+++ b/xwayland.h
@@ -13,6 +13,7 @@ struct cg_xwayland_view {
 	struct wl_listener unmap;
 	struct wl_listener map;
 	struct wl_listener request_fullscreen;
+	struct wl_listener set_geometry;
 };
 
 struct cg_xwayland_view *xwayland_view_from_view(struct cg_view *view);


### PR DESCRIPTION
Presumably this fixes #228.  The position of the scene node for XWayland override-redirect windows was never being set.