### PR TITLE
Add relative-pointer-unstable-v1 support

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -579,11 +579,7 @@ main(int argc, char *argv[])
 		goto end;
 	}
 
-	/* Place the cursor in the center of the output layout. */
-	struct wlr_box layout_box;
-	wlr_output_layout_get_box(server.output_layout, NULL, &layout_box);
-	wlr_cursor_warp(server.seat->cursor, NULL, layout_box.width / 2, layout_box.height / 2);
-
+	seat_center_cursor(server.seat);
 	wl_display_run(server.wl_display);
 
 #if CAGE_HAS_XWAYLAND

--- a/cage.c
+++ b/cage.c
@@ -30,6 +30,7 @@
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_presentation_time.h>
+#include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_server_decoration.h>
@@ -516,6 +517,13 @@ main(int argc, char *argv[])
 		goto end;
 	}
 	wl_signal_add(&virtual_pointer->events.new_virtual_pointer, &server.new_virtual_pointer);
+
+	server.relative_pointer_manager = wlr_relative_pointer_manager_v1_create(server.wl_display);
+	if (!server.relative_pointer_manager) {
+		wlr_log(WLR_ERROR, "Unable to create the relative pointer manager");
+		ret = 1;
+		goto end;
+	}
 
 #if CAGE_HAS_XWAYLAND
 	xwayland = wlr_xwayland_create(server.wl_display, compositor, true);

--- a/seat.c
+++ b/seat.c
@@ -944,3 +944,12 @@ seat_set_focus(struct cg_seat *seat, struct cg_view *view)
 
 	process_cursor_motion(seat, -1);
 }
+
+void
+seat_center_cursor(struct cg_seat *seat)
+{
+	/* Place the cursor in the center of the output layout. */
+	struct wlr_box layout_box;
+	wlr_output_layout_get_box(seat->server->output_layout, NULL, &layout_box);
+	wlr_cursor_warp(seat->cursor, NULL, layout_box.width / 2, layout_box.height / 2);
+}

--- a/seat.h
+++ b/seat.h
@@ -91,5 +91,6 @@ struct cg_seat *seat_create(struct cg_server *server, struct wlr_backend *backen
 void seat_destroy(struct cg_seat *seat);
 struct cg_view *seat_get_focus(struct cg_seat *seat);
 void seat_set_focus(struct cg_seat *seat, struct cg_view *view);
+void seat_center_cursor(struct cg_seat *seat);
 
 #endif

--- a/seat.h
+++ b/seat.h
@@ -27,7 +27,7 @@ struct cg_seat {
 
 	struct wlr_cursor *cursor;
 	struct wlr_xcursor_manager *xcursor_manager;
-	struct wl_listener cursor_motion;
+	struct wl_listener cursor_motion_relative;
 	struct wl_listener cursor_motion_absolute;
 	struct wl_listener cursor_button;
 	struct wl_listener cursor_axis;

--- a/server.h
+++ b/server.h
@@ -7,6 +7,7 @@
 #include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_xdg_decoration_v1.h>
 #if CAGE_HAS_XWAYLAND
 #include <wlr/xwayland.h>
@@ -50,6 +51,8 @@ struct cg_server {
 	struct wlr_output_manager_v1 *output_manager_v1;
 	struct wl_listener output_manager_apply;
 	struct wl_listener output_manager_test;
+
+	struct wlr_relative_pointer_manager_v1 *relative_pointer_manager;
 
 	bool xdg_decoration;
 	bool allow_vt_switch;


### PR DESCRIPTION
It should fix issue #286 as relative-pointer-unstable-v1 seems mandatory for RetroArch.
Once again, the code is inspired from Sway. I have added two minor extra commits which can me dropped if needed.

@vanfanel, it would be nice if you could give this branch a try with RetroArch.