### PR TITLE
CI: Continue other jobs even if one job fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
   compile:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         CC: [ gcc, clang ]
         OS: [ "alpine:edge", "archlinux:base-devel" ]


### PR DESCRIPTION
Other jobs are canceled when one of the compile jobs fails.
This allows you to check how other things succeed or fail.


Reference: https://github.com/actions/runner/issues/2347