### PR TITLE
ci: Reduce build matrix size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         OS: [ "alpine:edge", "archlinux:base-devel" ]
-        xwayland: [ enabled, disabled ]
     container: ${{ matrix.OS }}
     steps:
       - name: Checkout Cage
@@ -31,11 +30,15 @@ jobs:
       - name: Fetch wlroots as a subproject
         run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.17.0
 
-      # TODO: use --fatal-meson-warnings when on wlroots 0.15.0
-      - name: Compile Cage (XWayland=${{ matrix.xwayland }})
+      - name: Compile Cage
         run: |
-          meson build-${{ matrix.CC }}-${{matrix.xwayland }} -Dxwayland=${{ matrix.xwayland }}
-          ninja -C build-${{ matrix.CC }}-${{matrix.xwayland }}
+          meson setup build -Dxwayland=enabled
+          ninja -C build
+
+      - name: Compile cage (no xwayland)
+        run: |
+          meson configure build -Dxwayland=disabled
+          ninja -C build
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        CC: [ gcc, clang ]
         OS: [ "alpine:edge", "archlinux:base-devel" ]
         xwayland: [ enabled, disabled ]
     container: ${{ matrix.OS }}
-    env:
-      CC: ${{ matrix.CC }}
     steps:
       - name: Checkout Cage
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         CC: [ gcc, clang ]
         OS: [ "alpine:edge", "archlinux:base-devel" ]
-        xwayland: [ true, false ]
+        xwayland: [ enabled, disabled ]
     container: ${{ matrix.OS }}
     env:
       CC: ${{ matrix.CC }}
@@ -54,7 +54,7 @@ jobs:
         run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.16.0
       - name: Check for formatting changes
         run: |
-          meson build-clang-format -Dxwayland=true
+          meson build-clang-format -Dxwayland=enabled
           ninja -C build-clang-format clang-format-check
 
   scan-build:
@@ -73,5 +73,5 @@ jobs:
         run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.16.0
       - name: Run scan-build
         run: |
-          meson build-scan-build -Dxwayland=true
+          meson build-scan-build -Dxwayland=enabled
           ninja -C build-scan-build scan-build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           pacman -Syu --noconfirm xcb-util-wm seatd git clang meson libinput libdrm mesa libxkbcommon wayland wayland-protocols xorg-server-xwayland scdoc
 
       - name: Fetch wlroots as a subproject
-        run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.16.0
+        run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.17.0
 
       # TODO: use --fatal-meson-warnings when on wlroots 0.15.0
       - name: Compile Cage (XWayland=${{ matrix.xwayland }})
@@ -51,7 +51,7 @@ jobs:
           pacman-key --init
           pacman -Syu --noconfirm xcb-util-wm seatd git clang meson libinput libdrm mesa libxkbcommon wayland wayland-protocols xorg-server-xwayland scdoc hwdata
       - name: Fetch wlroots as a subproject
-        run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.16.0
+        run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.17.0
       - name: Check for formatting changes
         run: |
           meson build-clang-format -Dxwayland=enabled
@@ -70,7 +70,7 @@ jobs:
           pacman-key --init
           pacman -Syu --noconfirm xcb-util-wm seatd git clang meson libinput libdrm mesa libxkbcommon wayland wayland-protocols xorg-server-xwayland scdoc hwdata
       - name: Fetch wlroots as a subproject
-        run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.16.0
+        run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.17.0
       - name: Run scan-build
         run: |
           meson build-scan-build -Dxwayland=enabled

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies (Alpine)
         if: "matrix.OS == 'alpine:edge'"
-        run: apk add build-base xcb-util-wm-dev libseat-dev clang git eudev-dev mesa-dev libdrm-dev libinput-dev libxkbcommon-dev pixman-dev wayland-dev meson wayland-protocols xwayland scdoc-doc hwdata
+        run: apk add build-base xcb-util-wm-dev libseat-dev clang git eudev-dev mesa-dev libdrm-dev libinput-dev libxkbcommon-dev pixman-dev wayland-dev meson wayland-protocols xwayland-dev scdoc-doc hwdata
 
       - name: Install dependencies (Arch)
         if: "matrix.OS == 'archlinux:base-devel'"

--- a/cage.c
+++ b/cage.c
@@ -342,7 +342,7 @@ main(int argc, char *argv[])
 
 	wlr_scene_attach_output_layout(server.scene, server.output_layout);
 
-	struct wlr_compositor *compositor = wlr_compositor_create(server.wl_display, server.renderer);
+	struct wlr_compositor *compositor = wlr_compositor_create(server.wl_display, 6, server.renderer);
 	if (!compositor) {
 		wlr_log(WLR_ERROR, "Unable to create the wlroots compositor");
 		ret = 1;

--- a/cage.c
+++ b/cage.c
@@ -293,7 +293,7 @@ main(int argc, char *argv[])
 	struct wl_event_source *sigterm_source =
 		wl_event_loop_add_signal(event_loop, SIGTERM, handle_signal, &server.wl_display);
 
-	server.backend = wlr_backend_autocreate(server.wl_display);
+	server.backend = wlr_backend_autocreate(server.wl_display, &server.session);
 	if (!server.backend) {
 		wlr_log(WLR_ERROR, "Unable to create the wlroots backend");
 		ret = 1;

--- a/cage.c
+++ b/cage.c
@@ -25,8 +25,8 @@
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
-#include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
+#include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_presentation_time.h>
@@ -374,7 +374,7 @@ main(int argc, char *argv[])
 		goto end;
 	}
 
-	server.idle = wlr_idle_create(server.wl_display);
+	server.idle = wlr_idle_notifier_v1_create(server.wl_display);
 	if (!server.idle) {
 		wlr_log(WLR_ERROR, "Unable to create the idle tracker");
 		ret = 1;

--- a/idle_inhibit_v1.c
+++ b/idle_inhibit_v1.c
@@ -8,8 +8,8 @@
 
 #include <stdlib.h>
 #include <wayland-server-core.h>
-#include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
+#include <wlr/types/wlr_idle_notify_v1.h>
 
 #include "idle_inhibit_v1.h"
 #include "server.h"
@@ -32,7 +32,7 @@ idle_inhibit_v1_check_active(struct cg_server *server)
 	   Hence, we simply check for any inhibitors and inhibit
 	   accordingly. */
 	bool inhibited = !wl_list_empty(&server->inhibitors);
-	wlr_idle_set_enabled(server->idle, NULL, !inhibited);
+	wlr_idle_notifier_v1_set_inhibited(server->idle, inhibited);
 }
 
 static void

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ if is_freebsd
   )
 endif
 
-wlroots        = dependency('wlroots', version: '>= 0.16.0', fallback: ['wlroots', 'wlroots'])
+wlroots        = dependency('wlroots', version: '>= 0.17.0', fallback: ['wlroots', 'wlroots'])
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 wayland_server = dependency('wayland-server')
 xkbcommon      = dependency('xkbcommon')

--- a/meson.build
+++ b/meson.build
@@ -64,9 +64,9 @@ server_protos = declare_dependency(
   sources: server_protos_headers,
 )
 
-if get_option('xwayland')
+if not get_option('xwayland').disabled()
   wlroots_has_xwayland = wlroots.get_variable(pkgconfig: 'have_xwayland', internal: 'have_xwayland') == 'true'
-  if not wlroots_has_xwayland
+  if get_option('xwayland').enabled() and not wlroots_has_xwayland
     error('Cannot build Cage with XWayland support: wlroots has been built without it')
   endif
   have_xwayland = true

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,2 @@
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
-option('xwayland', type: 'boolean', value: false, description: 'Enable support for X11 applications')
+option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')

--- a/output.c
+++ b/output.c
@@ -70,24 +70,21 @@ update_output_manager_config(struct cg_server *server)
 static inline void
 output_layout_add_auto(struct cg_output *output)
 {
-	wlr_output_layout_add_auto(output->server->output_layout, output->wlr_output);
-	output->scene_output = wlr_scene_get_scene_output(output->server->scene, output->wlr_output);
 	assert(output->scene_output != NULL);
+	wlr_output_layout_add_auto(output->server->output_layout, output->wlr_output);
 }
 
 static inline void
 output_layout_add(struct cg_output *output, int32_t x, int32_t y)
 {
-	wlr_output_layout_add(output->server->output_layout, output->wlr_output, x, y);
-	output->scene_output = wlr_scene_get_scene_output(output->server->scene, output->wlr_output);
 	assert(output->scene_output != NULL);
+	wlr_output_layout_add(output->server->output_layout, output->wlr_output, x, y);
 }
 
 static inline void
 output_layout_remove(struct cg_output *output)
 {
 	wlr_output_layout_remove(output->server->output_layout, output->wlr_output);
-	output->scene_output = NULL;
 }
 
 static void
@@ -295,6 +292,8 @@ handle_new_output(struct wl_listener *listener, void *data)
 	wl_signal_add(&wlr_output->events.destroy, &output->destroy);
 	output->frame.notify = handle_output_frame;
 	wl_signal_add(&wlr_output->events.frame, &output->frame);
+
+	output->scene_output = wlr_scene_output_create(server->scene, wlr_output);
 
 	if (!wl_list_empty(&wlr_output->modes)) {
 		/* Ensure the output is marked as enabled before trying to set mode */

--- a/output.c
+++ b/output.c
@@ -191,19 +191,6 @@ handle_output_commit(struct wl_listener *listener, void *data)
 	}
 }
 
-static void
-handle_output_mode(struct wl_listener *listener, void *data)
-{
-	struct cg_output *output = wl_container_of(listener, output, mode);
-
-	if (!output->wlr_output->enabled) {
-		return;
-	}
-
-	view_position_all(output->server);
-	update_output_manager_config(output->server);
-}
-
 void
 handle_output_layout_change(struct wl_listener *listener, void *data)
 {
@@ -237,7 +224,6 @@ output_destroy(struct cg_output *output)
 
 	wl_list_remove(&output->destroy.link);
 	wl_list_remove(&output->commit.link);
-	wl_list_remove(&output->mode.link);
 	wl_list_remove(&output->frame.link);
 	wl_list_remove(&output->link);
 
@@ -286,8 +272,6 @@ handle_new_output(struct wl_listener *listener, void *data)
 
 	output->commit.notify = handle_output_commit;
 	wl_signal_add(&wlr_output->events.commit, &output->commit);
-	output->mode.notify = handle_output_mode;
-	wl_signal_add(&wlr_output->events.mode, &output->mode);
 	output->destroy.notify = handle_output_destroy;
 	wl_signal_add(&wlr_output->events.destroy, &output->destroy);
 	output->frame.notify = handle_output_frame;

--- a/output.c
+++ b/output.c
@@ -186,7 +186,7 @@ handle_output_commit(struct wl_listener *listener, void *data)
 	 * - output layout change will also be called if needed to position the views
 	 * - always update output manager configuration even if the output is now disabled */
 
-	if (event->committed & OUTPUT_CONFIG_UPDATED) {
+	if (event->state->committed & OUTPUT_CONFIG_UPDATED) {
 		update_output_manager_config(output->server);
 	}
 }

--- a/output.c
+++ b/output.c
@@ -26,7 +26,6 @@
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_output.h>
-#include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_scene.h>

--- a/output.c
+++ b/output.c
@@ -169,7 +169,7 @@ handle_output_frame(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	wlr_scene_output_commit(output->scene_output);
+	wlr_scene_output_commit(output->scene_output, NULL);
 
 	struct timespec now = {0};
 	clock_gettime(CLOCK_MONOTONIC, &now);

--- a/output.h
+++ b/output.h
@@ -3,7 +3,6 @@
 
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_output.h>
-#include <wlr/types/wlr_output_damage.h>
 
 #include "server.h"
 #include "view.h"

--- a/output.h
+++ b/output.h
@@ -13,7 +13,6 @@ struct cg_output {
 	struct wlr_scene_output *scene_output;
 
 	struct wl_listener commit;
-	struct wl_listener mode;
 	struct wl_listener destroy;
 	struct wl_listener frame;
 

--- a/seat.c
+++ b/seat.c
@@ -17,6 +17,7 @@
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/multi.h>
+#include <wlr/backend/session.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_idle.h>
@@ -263,10 +264,9 @@ handle_keybinding(struct cg_server *server, xkb_keysym_t sym)
 #endif
 	if (server->allow_vt_switch && sym >= XKB_KEY_XF86Switch_VT_1 && sym <= XKB_KEY_XF86Switch_VT_12) {
 		if (wlr_backend_is_multi(server->backend)) {
-			struct wlr_session *session = wlr_backend_get_session(server->backend);
-			if (session) {
+			if (server->session) {
 				unsigned vt = sym - XKB_KEY_XF86Switch_VT_1 + 1;
-				wlr_session_change_vt(session, vt);
+				wlr_session_change_vt(server->session, vt);
 			}
 		}
 	} else {

--- a/seat.c
+++ b/seat.c
@@ -65,7 +65,7 @@ desktop_view_at(struct cg_server *server, double lx, double ly, struct wlr_surfa
 	}
 
 	struct wlr_scene_buffer *scene_buffer = wlr_scene_buffer_from_node(node);
-	struct wlr_scene_surface *scene_surface = wlr_scene_surface_from_buffer(scene_buffer);
+	struct wlr_scene_surface *scene_surface = wlr_scene_surface_try_from_buffer(scene_buffer);
 	if (!scene_surface) {
 		return NULL;
 	}

--- a/seat.c
+++ b/seat.c
@@ -128,9 +128,9 @@ update_capabilities(struct cg_seat *seat)
 
 	/* Hide cursor if the seat doesn't have pointer capability. */
 	if ((caps & WL_SEAT_CAPABILITY_POINTER) == 0) {
-		wlr_cursor_set_image(seat->cursor, NULL, 0, 0, 0, 0, 0, 0);
+		wlr_cursor_unset_image(seat->cursor);
 	} else {
-		wlr_xcursor_manager_set_cursor_image(seat->xcursor_manager, DEFAULT_XCURSOR, seat->cursor);
+		wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager, DEFAULT_XCURSOR);
 	}
 }
 

--- a/seat.c
+++ b/seat.c
@@ -20,7 +20,7 @@
 #include <wlr/backend/session.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_data_device.h>
-#include <wlr/types/wlr_idle.h>
+#include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_keyboard_group.h>
 #include <wlr/types/wlr_primary_selection.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
@@ -250,7 +250,7 @@ handle_modifier_event(struct wlr_keyboard *keyboard, struct cg_seat *seat)
 	wlr_seat_set_keyboard(seat->seat, keyboard);
 	wlr_seat_keyboard_notify_modifiers(seat->seat, &keyboard->modifiers);
 
-	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
 static bool
@@ -272,7 +272,7 @@ handle_keybinding(struct cg_server *server, xkb_keysym_t sym)
 	} else {
 		return false;
 	}
-	wlr_idle_notify_activity(server->idle, server->seat->seat);
+	wlr_idle_notifier_v1_notify_activity(server->idle, server->seat->seat);
 	return true;
 }
 
@@ -304,7 +304,7 @@ handle_key_event(struct wlr_keyboard *keyboard, struct cg_seat *seat, void *data
 		wlr_seat_keyboard_notify_key(seat->seat, event->time_msec, event->keycode, event->state);
 	}
 
-	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
 static void
@@ -512,7 +512,7 @@ handle_touch_down(struct wl_listener *listener, void *data)
 		press_cursor_button(seat, &event->touch->base, event->time_msec, BTN_LEFT, WLR_BUTTON_PRESSED, lx, ly);
 	}
 
-	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
 static void
@@ -531,7 +531,7 @@ handle_touch_up(struct wl_listener *listener, void *data)
 	}
 
 	wlr_seat_touch_notify_up(seat->seat, event->time_msec, event->touch_id);
-	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
 static void
@@ -563,7 +563,7 @@ handle_touch_motion(struct wl_listener *listener, void *data)
 		seat->touch_ly = ly;
 	}
 
-	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
 static void
@@ -572,7 +572,7 @@ handle_touch_frame(struct wl_listener *listener, void *data)
 	struct cg_seat *seat = wl_container_of(listener, seat, touch_frame);
 
 	wlr_seat_touch_notify_frame(seat->seat);
-	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
 static void
@@ -581,7 +581,7 @@ handle_cursor_frame(struct wl_listener *listener, void *data)
 	struct cg_seat *seat = wl_container_of(listener, seat, cursor_frame);
 
 	wlr_seat_pointer_notify_frame(seat->seat);
-	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
 static void
@@ -592,7 +592,7 @@ handle_cursor_axis(struct wl_listener *listener, void *data)
 
 	wlr_seat_pointer_notify_axis(seat->seat, event->time_msec, event->orientation, event->delta,
 				     event->delta_discrete, event->source);
-	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
 static void
@@ -604,7 +604,7 @@ handle_cursor_button(struct wl_listener *listener, void *data)
 	wlr_seat_pointer_notify_button(seat->seat, event->time_msec, event->button, event->state);
 	press_cursor_button(seat, &event->pointer->base, event->time_msec, event->button, event->state, seat->cursor->x,
 			    seat->cursor->y);
-	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
 static void
@@ -634,7 +634,7 @@ process_cursor_motion(struct cg_seat *seat, uint32_t time_msec, double dx, doubl
 		drag_icon_update_position(drag_icon);
 	}
 
-	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
 static void
@@ -651,7 +651,7 @@ handle_cursor_motion_absolute(struct wl_listener *listener, void *data)
 
 	wlr_cursor_warp_absolute(seat->cursor, &event->pointer->base, event->x, event->y);
 	process_cursor_motion(seat, event->time_msec, dx, dy, dx, dy);
-	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
 static void
@@ -663,7 +663,7 @@ handle_cursor_motion_relative(struct wl_listener *listener, void *data)
 	wlr_cursor_move(seat->cursor, &event->pointer->base, event->delta_x, event->delta_y);
 	process_cursor_motion(seat, event->time_msec, event->delta_x, event->delta_y, event->unaccel_dx,
 			      event->unaccel_dy);
-	wlr_idle_notify_activity(seat->server->idle, seat->seat);
+	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
 static void

--- a/server.h
+++ b/server.h
@@ -4,8 +4,8 @@
 #include "config.h"
 
 #include <wayland-server-core.h>
-#include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
+#include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_xdg_decoration_v1.h>
@@ -27,7 +27,7 @@ struct cg_server {
 	struct wlr_session *session;
 
 	struct cg_seat *seat;
-	struct wlr_idle *idle;
+	struct wlr_idle_notifier_v1 *idle;
 	struct wlr_idle_inhibit_manager_v1 *idle_inhibit_v1;
 	struct wl_listener new_idle_inhibitor_v1;
 	struct wl_list inhibitors;

--- a/server.h
+++ b/server.h
@@ -24,6 +24,7 @@ struct cg_server {
 	struct wlr_backend *backend;
 	struct wlr_renderer *renderer;
 	struct wlr_allocator *allocator;
+	struct wlr_session *session;
 
 	struct cg_seat *seat;
 	struct wlr_idle *idle;

--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -238,9 +238,9 @@ handle_xdg_shell_surface_new(struct wl_listener *listener, void *data)
 		xdg_shell_view->xdg_toplevel = xdg_surface->toplevel;
 
 		xdg_shell_view->map.notify = handle_xdg_shell_surface_map;
-		wl_signal_add(&xdg_surface->events.map, &xdg_shell_view->map);
+		wl_signal_add(&xdg_surface->surface->events.map, &xdg_shell_view->map);
 		xdg_shell_view->unmap.notify = handle_xdg_shell_surface_unmap;
-		wl_signal_add(&xdg_surface->events.unmap, &xdg_shell_view->unmap);
+		wl_signal_add(&xdg_surface->surface->events.unmap, &xdg_shell_view->unmap);
 		xdg_shell_view->destroy.notify = handle_xdg_shell_surface_destroy;
 		wl_signal_add(&xdg_surface->events.destroy, &xdg_shell_view->destroy);
 		xdg_shell_view->request_fullscreen.notify = handle_xdg_shell_surface_request_fullscreen;

--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -46,11 +46,13 @@ static struct cg_view *
 popup_get_view(struct wlr_xdg_popup *popup)
 {
 	while (true) {
-		if (popup->parent == NULL || !wlr_surface_is_xdg_surface(popup->parent)) {
+		if (popup->parent == NULL) {
 			return NULL;
 		}
-
-		struct wlr_xdg_surface *xdg_surface = wlr_xdg_surface_from_wlr_surface(popup->parent);
+		struct wlr_xdg_surface *xdg_surface = wlr_xdg_surface_try_from_wlr_surface(popup->parent);
+		if (xdg_surface == NULL) {
+			return NULL;
+		}
 		switch (xdg_surface->role) {
 		case WLR_XDG_SURFACE_ROLE_TOPLEVEL:
 			return xdg_surface->data;
@@ -254,7 +256,10 @@ handle_xdg_shell_surface_new(struct wl_listener *listener, void *data)
 		}
 
 		struct wlr_scene_tree *parent_scene_tree = NULL;
-		struct wlr_xdg_surface *parent = wlr_xdg_surface_from_wlr_surface(popup->parent);
+		struct wlr_xdg_surface *parent = wlr_xdg_surface_try_from_wlr_surface(popup->parent);
+		if (parent == NULL) {
+			return;
+		}
 		switch (parent->role) {
 		case WLR_XDG_SURFACE_ROLE_TOPLEVEL:;
 			parent_scene_tree = view->scene_tree;

--- a/xwayland.c
+++ b/xwayland.c
@@ -167,9 +167,9 @@ handle_xwayland_surface_new(struct wl_listener *listener, void *data)
 	xwayland_view->xwayland_surface = xwayland_surface;
 
 	xwayland_view->map.notify = handle_xwayland_surface_map;
-	wl_signal_add(&xwayland_surface->events.map, &xwayland_view->map);
+	wl_signal_add(&xwayland_surface->surface->events.map, &xwayland_view->map);
 	xwayland_view->unmap.notify = handle_xwayland_surface_unmap;
-	wl_signal_add(&xwayland_surface->events.unmap, &xwayland_view->unmap);
+	wl_signal_add(&xwayland_surface->surface->events.unmap, &xwayland_view->unmap);
 	xwayland_view->destroy.notify = handle_xwayland_surface_destroy;
 	wl_signal_add(&xwayland_surface->events.destroy, &xwayland_view->destroy);
 	xwayland_view->request_fullscreen.notify = handle_xwayland_surface_request_fullscreen;


### PR DESCRIPTION
Significantly reduce the build matrix size for simpler results and less build scheduling latency. Drops multi-compiler tests.