### PR TITLE
Add support for wlroots v0.18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           pacman -Syu --noconfirm xcb-util-wm seatd git clang meson libinput libdrm mesa libxkbcommon wayland wayland-protocols xorg-server-xwayland scdoc
 
       - name: Fetch wlroots as a subproject
-        run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.17
+        run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.18
 
       - name: Compile Cage (XWayland=${{ matrix.xwayland }})
         run: |
@@ -52,7 +52,7 @@ jobs:
           pacman-key --init
           pacman -Syu --noconfirm xcb-util-wm seatd git clang meson libinput libdrm mesa libxkbcommon wayland wayland-protocols xorg-server-xwayland scdoc hwdata
       - name: Fetch wlroots as a subproject
-        run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.17
+        run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.18
       - name: Check for formatting changes
         run: |
           meson build-clang-format -Dwlroots:xwayland=enabled
@@ -71,7 +71,7 @@ jobs:
           pacman-key --init
           pacman -Syu --noconfirm xcb-util-wm seatd git clang meson libinput libdrm mesa libxkbcommon wayland wayland-protocols xorg-server-xwayland scdoc hwdata
       - name: Fetch wlroots as a subproject
-        run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.17
+        run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.18
       - name: Run scan-build
         run: |
           meson build-scan-build -Dwlroots:xwayland=enabled

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,11 +34,14 @@ jobs:
       - name: Fetch wlroots as a subproject
         run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.18
 
+      # TODO: drop explicit c_std when this is released:
+      # https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/401
       - name: Compile Cage (XWayland=${{ matrix.xwayland }})
         run: |
           meson --fatal-meson-warnings \
             build-${{ matrix.CC }}-${{matrix.xwayland }} \
-            -Dwlroots:xwayland=${{ matrix.xwayland }}
+            -Dwlroots:xwayland=${{ matrix.xwayland }} \
+            -Dwlroots:c_std=c11
           ninja -C build-${{ matrix.CC }}-${{matrix.xwayland }}
 
   format:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ All releases are published on [GitHub](https://github.com/cage-kiosk/cage/releas
 
 You can build Cage with the [meson](https://mesonbuild.com/) build system. It
 requires wayland, wlroots, and xkbcommon to be installed. Optionally, install
-scdoc for manual pages. Cage is currently based on branch 0.17 of wlroots.
+scdoc for manual pages. Cage is currently based on branch 0.18 of wlroots.
 
 Simply execute the following steps to build Cage:
 

--- a/cage.c
+++ b/cage.c
@@ -440,7 +440,6 @@ main(int argc, char *argv[])
 		ret = 1;
 		goto end;
 	}
-	wlr_scene_set_presentation(server.scene, presentation);
 
 	if (!wlr_export_dmabuf_manager_v1_create(server.wl_display)) {
 		wlr_log(WLR_ERROR, "Unable to create the export DMABUF manager");

--- a/cage.c
+++ b/cage.c
@@ -61,6 +61,24 @@
 #include "xwayland.h"
 #endif
 
+void
+server_terminate(struct cg_server *server)
+{
+	// Workaround for https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/421
+	if (server->terminated) {
+		return;
+	}
+
+	wl_display_terminate(server->wl_display);
+}
+
+static void
+handle_display_destroy(struct wl_listener *listener, void *data)
+{
+	struct cg_server *server = wl_container_of(listener, server, display_destroy);
+	server->terminated = true;
+}
+
 static int
 sigchld_handler(int fd, uint32_t mask, void *data)
 {
@@ -76,7 +94,7 @@ sigchld_handler(int fd, uint32_t mask, void *data)
 	}
 
 	server->return_app_code = true;
-	wl_display_terminate(server->wl_display);
+	server_terminate(server);
 	return 0;
 }
 
@@ -189,13 +207,13 @@ drop_permissions(void)
 static int
 handle_signal(int signal, void *data)
 {
-	struct wl_display *display = data;
+	struct cg_server *server = data;
 
 	switch (signal) {
 	case SIGINT:
 		/* Fallthrough */
 	case SIGTERM:
-		wl_display_terminate(display);
+		server_terminate(server);
 		return 0;
 	default:
 		return 0;
@@ -288,11 +306,12 @@ main(int argc, char *argv[])
 		return 1;
 	}
 
+	server.display_destroy.notify = handle_display_destroy;
+	wl_display_add_destroy_listener(server.wl_display, &server.display_destroy);
+
 	struct wl_event_loop *event_loop = wl_display_get_event_loop(server.wl_display);
-	struct wl_event_source *sigint_source =
-		wl_event_loop_add_signal(event_loop, SIGINT, handle_signal, server.wl_display);
-	struct wl_event_source *sigterm_source =
-		wl_event_loop_add_signal(event_loop, SIGTERM, handle_signal, server.wl_display);
+	struct wl_event_source *sigint_source = wl_event_loop_add_signal(event_loop, SIGINT, handle_signal, &server);
+	struct wl_event_source *sigterm_source = wl_event_loop_add_signal(event_loop, SIGTERM, handle_signal, &server);
 
 	server.backend = wlr_backend_autocreate(event_loop, &server.session);
 	if (!server.backend) {

--- a/cage.c
+++ b/cage.c
@@ -404,8 +404,10 @@ main(int argc, char *argv[])
 		ret = 1;
 		goto end;
 	}
-	server.new_xdg_shell_surface.notify = handle_xdg_shell_surface_new;
-	wl_signal_add(&xdg_shell->events.new_surface, &server.new_xdg_shell_surface);
+	server.new_xdg_toplevel.notify = handle_new_xdg_toplevel;
+	wl_signal_add(&xdg_shell->events.new_toplevel, &server.new_xdg_toplevel);
+	server.new_xdg_popup.notify = handle_new_xdg_popup;
+	wl_signal_add(&xdg_shell->events.new_popup, &server.new_xdg_popup);
 
 	struct wlr_xdg_decoration_manager_v1 *xdg_decoration_manager =
 		wlr_xdg_decoration_manager_v1_create(server.wl_display);

--- a/cage.c
+++ b/cage.c
@@ -294,7 +294,7 @@ main(int argc, char *argv[])
 	struct wl_event_source *sigterm_source =
 		wl_event_loop_add_signal(event_loop, SIGTERM, handle_signal, server.wl_display);
 
-	server.backend = wlr_backend_autocreate(server.wl_display, &server.session);
+	server.backend = wlr_backend_autocreate(event_loop, &server.session);
 	if (!server.backend) {
 		wlr_log(WLR_ERROR, "Unable to create the wlroots backend");
 		ret = 1;
@@ -325,7 +325,7 @@ main(int argc, char *argv[])
 	wl_list_init(&server.views);
 	wl_list_init(&server.outputs);
 
-	server.output_layout = wlr_output_layout_create();
+	server.output_layout = wlr_output_layout_create(server.wl_display);
 	if (!server.output_layout) {
 		wlr_log(WLR_ERROR, "Unable to create output layout");
 		ret = 1;
@@ -596,6 +596,5 @@ end:
 	/* This function is not null-safe, but we only ever get here
 	   with a proper wl_display. */
 	wl_display_destroy(server.wl_display);
-	wlr_output_layout_destroy(server.output_layout);
 	return ret;
 }

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ if is_freebsd
   )
 endif
 
-wlroots        = dependency('wlroots', version: '>= 0.17.0', fallback: ['wlroots', 'wlroots'])
+wlroots        = dependency('wlroots-0.18', fallback: ['wlroots', 'wlroots'])
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 wayland_server = dependency('wayland-server')
 xkbcommon      = dependency('xkbcommon')

--- a/output.c
+++ b/output.c
@@ -240,7 +240,7 @@ output_destroy(struct cg_output *output)
 	free(output);
 
 	if (wl_list_empty(&server->outputs) && was_nested_output) {
-		wl_display_terminate(server->wl_display);
+		server_terminate(server);
 	} else if (server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST && !wl_list_empty(&server->outputs)) {
 		struct cg_output *prev = wl_container_of(server->outputs.next, prev, link);
 		output_enable(prev);

--- a/seat.c
+++ b/seat.c
@@ -441,7 +441,7 @@ handle_new_input(struct wl_listener *listener, void *data)
 	case WLR_INPUT_DEVICE_SWITCH:
 		wlr_log(WLR_DEBUG, "Switch input is not implemented");
 		return;
-	case WLR_INPUT_DEVICE_TABLET_TOOL:
+	case WLR_INPUT_DEVICE_TABLET:
 	case WLR_INPUT_DEVICE_TABLET_PAD:
 		wlr_log(WLR_DEBUG, "Tablet input is not implemented");
 		return;

--- a/seat.c
+++ b/seat.c
@@ -591,7 +591,7 @@ handle_cursor_axis(struct wl_listener *listener, void *data)
 	struct wlr_pointer_axis_event *event = data;
 
 	wlr_seat_pointer_notify_axis(seat->seat, event->time_msec, event->orientation, event->delta,
-				     event->delta_discrete, event->source);
+				     event->delta_discrete, event->source, event->relative_direction);
 	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 

--- a/seat.c
+++ b/seat.c
@@ -258,7 +258,7 @@ handle_keybinding(struct cg_server *server, xkb_keysym_t sym)
 {
 #ifdef DEBUG
 	if (sym == XKB_KEY_Escape) {
-		wl_display_terminate(server->wl_display);
+		server_terminate(server);
 		return true;
 	}
 #endif

--- a/server.h
+++ b/server.h
@@ -44,7 +44,8 @@ struct cg_server {
 	struct wl_listener output_layout_change;
 
 	struct wl_listener xdg_toplevel_decoration;
-	struct wl_listener new_xdg_shell_surface;
+	struct wl_listener new_xdg_toplevel;
+	struct wl_listener new_xdg_popup;
 
 	struct wl_listener new_virtual_keyboard;
 	struct wl_listener new_virtual_pointer;

--- a/server.h
+++ b/server.h
@@ -25,6 +25,7 @@ struct cg_server {
 	struct wlr_renderer *renderer;
 	struct wlr_allocator *allocator;
 	struct wlr_session *session;
+	struct wl_listener display_destroy;
 
 	struct cg_seat *seat;
 	struct wlr_idle_notifier_v1 *idle;
@@ -61,6 +62,9 @@ struct cg_server {
 	bool xdg_decoration;
 	bool allow_vt_switch;
 	bool return_app_code;
+	bool terminated;
 };
+
+void server_terminate(struct cg_server *server);
 
 #endif

--- a/view.c
+++ b/view.c
@@ -67,7 +67,9 @@ view_maximize(struct cg_view *view, struct wlr_box *layout_box)
 	view->lx = layout_box->x;
 	view->ly = layout_box->y;
 
-	wlr_scene_node_set_position(&view->scene_tree->node, view->lx, view->ly);
+	if (view->scene_tree) {
+		wlr_scene_node_set_position(&view->scene_tree->node, view->lx, view->ly);
+	}
 
 	view->impl->maximize(view, layout_box->width, layout_box->height);
 }
@@ -81,7 +83,9 @@ view_center(struct cg_view *view, struct wlr_box *layout_box)
 	view->lx = (layout_box->width - width) / 2;
 	view->ly = (layout_box->height - height) / 2;
 
-	wlr_scene_node_set_position(&view->scene_tree->node, view->lx, view->ly);
+	if (view->scene_tree) {
+		wlr_scene_node_set_position(&view->scene_tree->node, view->lx, view->ly);
+	}
 }
 
 void

--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -19,27 +19,46 @@
 #include "xdg_shell.h"
 
 static void
-xdg_decoration_handle_destroy(struct wl_listener *listener, void *data)
+xdg_decoration_set_mode(struct cg_xdg_decoration *xdg_decoration)
 {
-	struct cg_xdg_decoration *xdg_decoration = wl_container_of(listener, xdg_decoration, destroy);
-
-	wl_list_remove(&xdg_decoration->destroy.link);
-	wl_list_remove(&xdg_decoration->request_mode.link);
-	free(xdg_decoration);
-}
-
-static void
-xdg_decoration_handle_request_mode(struct wl_listener *listener, void *data)
-{
-	struct cg_xdg_decoration *xdg_decoration = wl_container_of(listener, xdg_decoration, request_mode);
 	enum wlr_xdg_toplevel_decoration_v1_mode mode;
-
 	if (xdg_decoration->server->xdg_decoration) {
 		mode = WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE;
 	} else {
 		mode = WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE;
 	}
 	wlr_xdg_toplevel_decoration_v1_set_mode(xdg_decoration->wlr_decoration, mode);
+}
+
+static void
+xdg_decoration_handle_destroy(struct wl_listener *listener, void *data)
+{
+	struct cg_xdg_decoration *xdg_decoration = wl_container_of(listener, xdg_decoration, destroy);
+
+	wl_list_remove(&xdg_decoration->destroy.link);
+	wl_list_remove(&xdg_decoration->commit.link);
+	wl_list_remove(&xdg_decoration->request_mode.link);
+	free(xdg_decoration);
+}
+
+static void
+xdg_decoration_handle_commit(struct wl_listener *listener, void *data)
+{
+	struct cg_xdg_decoration *xdg_decoration = wl_container_of(listener, xdg_decoration, commit);
+
+	if (xdg_decoration->wlr_decoration->toplevel->base->initial_commit) {
+		xdg_decoration_set_mode(xdg_decoration);
+	}
+}
+
+static void
+xdg_decoration_handle_request_mode(struct wl_listener *listener, void *data)
+{
+	struct cg_xdg_decoration *xdg_decoration = wl_container_of(listener, xdg_decoration, request_mode);
+
+	if (xdg_decoration->wlr_decoration->toplevel->base->initialized) {
+		xdg_decoration_set_mode(xdg_decoration);
+	}
 }
 
 static struct cg_view *
@@ -321,8 +340,8 @@ handle_xdg_toplevel_decoration(struct wl_listener *listener, void *data)
 
 	xdg_decoration->destroy.notify = xdg_decoration_handle_destroy;
 	wl_signal_add(&wlr_decoration->events.destroy, &xdg_decoration->destroy);
+	xdg_decoration->commit.notify = xdg_decoration_handle_commit;
+	wl_signal_add(&wlr_decoration->toplevel->base->surface->events.commit, &xdg_decoration->commit);
 	xdg_decoration->request_mode.notify = xdg_decoration_handle_request_mode;
 	wl_signal_add(&wlr_decoration->events.request_mode, &xdg_decoration->request_mode);
-
-	xdg_decoration_handle_request_mode(&xdg_decoration->request_mode, wlr_decoration);
 }

--- a/xdg_shell.h
+++ b/xdg_shell.h
@@ -24,7 +24,8 @@ struct cg_xdg_decoration {
 	struct wl_listener request_mode;
 };
 
-void handle_xdg_shell_surface_new(struct wl_listener *listener, void *data);
+void handle_new_xdg_toplevel(struct wl_listener *listener, void *data);
+void handle_new_xdg_popup(struct wl_listener *listener, void *data);
 
 void handle_xdg_toplevel_decoration(struct wl_listener *listener, void *data);
 

--- a/xdg_shell.h
+++ b/xdg_shell.h
@@ -22,6 +22,7 @@ struct cg_xdg_decoration {
 	struct wlr_xdg_toplevel_decoration_v1 *wlr_decoration;
 	struct cg_server *server;
 	struct wl_listener destroy;
+	struct wl_listener commit;
 	struct wl_listener request_mode;
 };
 

--- a/xdg_shell.h
+++ b/xdg_shell.h
@@ -26,6 +26,13 @@ struct cg_xdg_decoration {
 	struct wl_listener request_mode;
 };
 
+struct cg_xdg_popup {
+	struct wlr_xdg_popup *xdg_popup;
+
+	struct wl_listener destroy;
+	struct wl_listener commit;
+};
+
 void handle_new_xdg_toplevel(struct wl_listener *listener, void *data);
 void handle_new_xdg_popup(struct wl_listener *listener, void *data);
 

--- a/xdg_shell.h
+++ b/xdg_shell.h
@@ -12,6 +12,7 @@ struct cg_xdg_shell_view {
 	struct wlr_xdg_toplevel *xdg_toplevel;
 
 	struct wl_listener destroy;
+	struct wl_listener commit;
 	struct wl_listener unmap;
 	struct wl_listener map;
 	struct wl_listener request_fullscreen;


### PR DESCRIPTION
Upstream breaking changes: https://gitlab.freedesktop.org/wlroots/wlroots/-/releases/0.18.0

TODO:

- Check out wlroots 0.18 branch in CI
- Fix the following:

```
00:00:00.168 [types/xdg_shell/wlr_xdg_surface.c:169] A configure is scheduled for an uninitialized xdg_surface
```

- Fix the following on exit:

```
cage: ../wayland-1.22.0/src/wayland-server.c:1483: wl_display_terminate: Assertion `ret >= 0 || errno == EAGAIN' failed.
```