### PR TITLE
output: fix assert when re-adding output to layout

### DIFF
--- a/output.c
+++ b/output.c
@@ -80,8 +80,12 @@ static inline void
 output_layout_add(struct cg_output *output, int32_t x, int32_t y)
 {
 	assert(output->scene_output != NULL);
+	bool exists = wlr_output_layout_get(output->server->output_layout, output->wlr_output);
 	struct wlr_output_layout_output *layout_output =
 		wlr_output_layout_add(output->server->output_layout, output->wlr_output, x, y);
+	if (exists) {
+		return;
+	}
 	wlr_scene_output_layout_add_output(output->server->scene_output_layout, layout_output, output->scene_output);
 }
 


### PR DESCRIPTION
wlr_scene_output_layout_add_output() aborts when called with an already-added output.

To reproduce, run wlr-randr to reconfigure one of the enabled outputs.

cc @kennylevinsen 