### PR TITLE
Command line option to hide cursor.

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -208,6 +208,7 @@ usage(FILE *file, const char *cage)
 	fprintf(file,
 		"Usage: %s [OPTIONS] [--] APPLICATION\n"
 		"\n"
+		" -c\t Hide cursor\n"
 		" -d\t Don't draw client side decorations, when possible\n"
 		" -h\t Display this help message\n"
 		" -m extend Extend the display across all connected outputs (default)\n"
@@ -223,8 +224,11 @@ static bool
 parse_args(struct cg_server *server, int argc, char *argv[])
 {
 	int c;
-	while ((c = getopt(argc, argv, "dhm:sv")) != -1) {
+	while ((c = getopt(argc, argv, "cdhm:sv")) != -1) {
 		switch (c) {
+		case 'c':
+			server->hide_cursor = true;
+			break;
 		case 'd':
 			server->xdg_decoration = true;
 			break;

--- a/seat.c
+++ b/seat.c
@@ -127,7 +127,7 @@ update_capabilities(struct cg_seat *seat)
 	wlr_seat_set_capabilities(seat->seat, caps);
 
 	/* Hide cursor if the seat doesn't have pointer capability. */
-	if ((caps & WL_SEAT_CAPABILITY_POINTER) == 0) {
+	if ((caps & WL_SEAT_CAPABILITY_POINTER) == 0 || seat->server->hide_cursor == true) {
 		wlr_cursor_unset_image(seat->cursor);
 	} else {
 		wlr_cursor_set_xcursor(seat->cursor, seat->xcursor_manager, DEFAULT_XCURSOR);
@@ -482,7 +482,7 @@ handle_request_set_cursor(struct wl_listener *listener, void *data)
 
 	/* This can be sent by any client, so we check to make sure
 	 * this one actually has pointer focus first. */
-	if (focused_client == event->seat_client->client) {
+	if (focused_client == event->seat_client->client && seat->server->hide_cursor == false) {
 		wlr_cursor_set_surface(seat->cursor, event->surface, event->hotspot_x, event->hotspot_y);
 	}
 }

--- a/server.h
+++ b/server.h
@@ -60,6 +60,7 @@ struct cg_server {
 	bool xdg_decoration;
 	bool allow_vt_switch;
 	bool return_app_code;
+	bool hide_cursor;
 };
 
 #endif


### PR DESCRIPTION
Adds a command line option to hide the cursor, regardless if any pointer capable devices are available or not.

I have some peripherals plugged in that, for some reason, have the pointer capability available even if they can not control the mouse pointer. This is a quick fix for that. I'm not sure how niche this problem is, but there is an issue regarding an hdmi device with "pointer capabilities" that would be fixed by this PR.

Fixes #299.

P.S. `update_capabilities` and `handle_request_set_cursor` seem redundant in setting and unsetting the visibility of the cursor i.e. if you delete one or the other, nothing changes