### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ build --buildtype=release`.
 
 Cage comes with compile-time support for XWayland. To enable this,
 first make sure that your version of wlroots is compiled with this
-option. Then, add `-Dxwayland=true` to the `meson` command above. Note
+option. Then, add `-Dxwayland=enabled` to the `meson` command above. Note
 that you'll need to have the XWayland binary installed on your system
 for this to work.
 


### PR DESCRIPTION
Change 'true' for 'enabled' as per the error  message received from meson:

~~~

meson.build:1:0: ERROR: Value "true" (of type "string") for combo option "Enable support for X11 applications" is not one of the choices. Possible choices are (as string): "enabled", "disabled", "auto". 

~~~