### PR TITLE
build: drop xwayland option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       # TODO: use --fatal-meson-warnings when on wlroots 0.15.0
       - name: Compile Cage (XWayland=${{ matrix.xwayland }})
         run: |
-          meson build-${{ matrix.CC }}-${{matrix.xwayland }} -Dxwayland=${{ matrix.xwayland }}
+          meson build-${{ matrix.CC }}-${{matrix.xwayland }} -Dwlroots:xwayland=${{ matrix.xwayland }}
           ninja -C build-${{ matrix.CC }}-${{matrix.xwayland }}
 
   format:
@@ -54,7 +54,7 @@ jobs:
         run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.17
       - name: Check for formatting changes
         run: |
-          meson build-clang-format -Dxwayland=enabled
+          meson build-clang-format -Dwlroots:xwayland=enabled
           ninja -C build-clang-format clang-format-check
 
   scan-build:
@@ -73,5 +73,5 @@ jobs:
         run: git clone https://gitlab.freedesktop.org/wlroots/wlroots.git subprojects/wlroots -b 0.17
       - name: Run scan-build
         run: |
-          meson build-scan-build -Dxwayland=enabled
+          meson build-scan-build -Dwlroots:xwayland=enabled
           ninja -C build-scan-build scan-build

--- a/README.md
+++ b/README.md
@@ -34,11 +34,9 @@ $ ninja -C build
 By default, this builds a debug build. To build a release build, use `meson
 build --buildtype=release`.
 
-Cage comes with compile-time support for XWayland. To enable this,
-first make sure that your version of wlroots is compiled with this
-option. Then, add `-Dxwayland=true` to the `meson` command above. Note
-that you'll need to have the XWayland binary installed on your system
-for this to work.
+Cage comes with compile-time support for XWayland. To enable this, make sure
+that your version of wlroots is compiled with this option. Note that you'll
+need to have the XWayland binary installed on your system for this to work.
 
 You can run Cage by running `./build/cage APPLICATION`. If you run it from
 within an existing X11 or Wayland session, it will open in a virtual output as

--- a/meson.build
+++ b/meson.build
@@ -64,15 +64,7 @@ server_protos = declare_dependency(
   sources: server_protos_headers,
 )
 
-if not get_option('xwayland').disabled()
-  wlroots_has_xwayland = wlroots.get_variable(pkgconfig: 'have_xwayland', internal: 'have_xwayland') == 'true'
-  if get_option('xwayland').enabled() and not wlroots_has_xwayland
-    error('Cannot build Cage with XWayland support: wlroots has been built without it')
-  endif
-  have_xwayland = true
-else
-  have_xwayland = false
-endif
+have_xwayland = wlroots.get_variable(pkgconfig: 'have_xwayland', internal: 'have_xwayland') == 'true'
 
 version = '@0@'.format(meson.project_version())
 git = find_program('git', native: true, required: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,1 @@
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
-option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')


### PR DESCRIPTION
This is unnecessary because Xwayland logic doesn't bring in new dependencies. We can just compile in our Xwayland-related code when wlroots has been built with Xwayland support.

See this Sway patch: https://github.com/swaywm/sway/pull/8165