### PR TITLE
view: adjust position according to declared top left corner

### DIFF
--- a/view.c
+++ b/view.c
@@ -55,17 +55,21 @@ view_activate(struct cg_view *view, bool activate)
 static bool
 view_extends_output_layout(struct cg_view *view, struct wlr_box *layout_box)
 {
-	int width, height;
-	view->impl->get_geometry(view, &width, &height);
+	struct wlr_box view_box;
+	view->impl->get_geometry(view, &view_box);
 
-	return (layout_box->height < height || layout_box->width < width);
+	return (layout_box->height < view_box.height || layout_box->width < view_box.width);
 }
 
 static void
 view_maximize(struct cg_view *view, struct wlr_box *layout_box)
 {
-	view->lx = layout_box->x;
-	view->ly = layout_box->y;
+	struct wlr_box view_box;
+	view->impl->get_geometry(view, &view_box);
+
+	// Do not forget to adjust position according to top left corner declared in view geometry
+	view->lx = layout_box->x - view_box.x;
+	view->ly = layout_box->y - view_box.y;
 
 	if (view->scene_tree) {
 		wlr_scene_node_set_position(&view->scene_tree->node, view->lx, view->ly);
@@ -77,11 +81,12 @@ view_maximize(struct cg_view *view, struct wlr_box *layout_box)
 static void
 view_center(struct cg_view *view, struct wlr_box *layout_box)
 {
-	int width, height;
-	view->impl->get_geometry(view, &width, &height);
+	struct wlr_box view_box;
+	view->impl->get_geometry(view, &view_box);
 
-	view->lx = (layout_box->width - width) / 2;
-	view->ly = (layout_box->height - height) / 2;
+	// Do not forget to adjust position according to top left corner declared in view geometry
+	view->lx = (layout_box->width - view_box.width) / 2 - view_box.x;
+	view->ly = (layout_box->height - view_box.height) / 2 - view_box.y;
 
 	if (view->scene_tree) {
 		wlr_scene_node_set_position(&view->scene_tree->node, view->lx, view->ly);

--- a/view.h
+++ b/view.h
@@ -36,7 +36,7 @@ struct cg_view {
 
 struct cg_view_impl {
 	char *(*get_title)(struct cg_view *view);
-	void (*get_geometry)(struct cg_view *view, int *width_out, int *height_out);
+	void (*get_geometry)(struct cg_view *view, struct wlr_box *view_box);
 	bool (*is_primary)(struct cg_view *view);
 	bool (*is_transient_for)(struct cg_view *child, struct cg_view *parent);
 	void (*activate)(struct cg_view *view, bool activate);

--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -125,14 +125,10 @@ get_title(struct cg_view *view)
 }
 
 static void
-get_geometry(struct cg_view *view, int *width_out, int *height_out)
+get_geometry(struct cg_view *view, struct wlr_box *view_box)
 {
 	struct cg_xdg_shell_view *xdg_shell_view = xdg_shell_view_from_view(view);
-	struct wlr_box geom;
-
-	wlr_xdg_surface_get_geometry(xdg_shell_view->xdg_toplevel->base, &geom);
-	*width_out = geom.width;
-	*height_out = geom.height;
+	wlr_xdg_surface_get_geometry(xdg_shell_view->xdg_toplevel->base, view_box);
 }
 
 static bool

--- a/xwayland.c
+++ b/xwayland.c
@@ -38,18 +38,22 @@ get_title(struct cg_view *view)
 }
 
 static void
-get_geometry(struct cg_view *view, int *width_out, int *height_out)
+get_geometry(struct cg_view *view, struct wlr_box *view_box)
 {
 	struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
 	struct wlr_xwayland_surface *xsurface = xwayland_view->xwayland_surface;
+
+	view_box->x = 0;
+	view_box->y = 0;
+
 	if (xsurface->surface == NULL) {
-		*width_out = 0;
-		*height_out = 0;
+		view_box->width = 0;
+		view_box->height = 0;
 		return;
 	}
 
-	*width_out = xsurface->surface->current.width;
-	*height_out = xsurface->surface->current.height;
+	view_box->width = xsurface->surface->current.width;
+	view_box->height = xsurface->surface->current.height;
 }
 
 static bool


### PR DESCRIPTION
The XDG surface geometry includes an (x,y) coordinate indicating the top left corner of the window. Use this information to correctly set the view position.

---

Split from PR #278, it should fix issue #254.