### PR TITLE
Map touch inputs to the single enabled display when the 'last' multi-display mode is in use

### DIFF
--- a/output.c
+++ b/output.c
@@ -113,6 +113,10 @@ output_enable(struct cg_output *output)
 	}
 
 	update_output_manager_config(output->server);
+
+	if (output->server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST) {
+		seat_remap_inputs_to_first_enabled_output(output->server->seat);
+	}
 }
 
 static void
@@ -332,6 +336,10 @@ handle_new_output(struct wl_listener *listener, void *data)
 
 	view_position_all(output->server);
 	update_output_manager_config(output->server);
+
+	if (output->server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST) {
+		seat_remap_inputs_to_first_enabled_output(output->server->seat);
+	}
 }
 
 void

--- a/seat.c
+++ b/seat.c
@@ -156,6 +156,20 @@ map_input_device_to_output(struct cg_seat *seat, struct wlr_input_device *device
 }
 
 static void
+map_input_device_to_first_enabled_output(struct cg_seat *seat, struct wlr_input_device *device)
+{
+	struct cg_output *output;
+	wl_list_for_each (output, &seat->server->outputs, link) {
+		if (output->wlr_output->enabled) {
+			map_input_device_to_output(seat, device, output->wlr_output->name);
+			return;
+		}
+	}
+
+	wlr_log(WLR_INFO, "No enabled output devices to  map input device %s to\n", device->name);
+}
+
+static void
 handle_touch_destroy(struct wl_listener *listener, void *data)
 {
 	struct cg_touch *touch = wl_container_of(listener, touch, destroy);
@@ -186,7 +200,11 @@ handle_new_touch(struct cg_seat *seat, struct wlr_touch *wlr_touch)
 	touch->destroy.notify = handle_touch_destroy;
 	wl_signal_add(&wlr_touch->base.events.destroy, &touch->destroy);
 
-	map_input_device_to_output(seat, &wlr_touch->base, wlr_touch->output_name);
+	if (seat->server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST) {
+		map_input_device_to_first_enabled_output(seat, &wlr_touch->base);
+	} else {
+		map_input_device_to_output(seat, &wlr_touch->base, wlr_touch->output_name);
+	}
 }
 
 static void
@@ -220,7 +238,11 @@ handle_new_pointer(struct cg_seat *seat, struct wlr_pointer *wlr_pointer)
 	pointer->destroy.notify = handle_pointer_destroy;
 	wl_signal_add(&wlr_pointer->base.events.destroy, &pointer->destroy);
 
-	map_input_device_to_output(seat, &wlr_pointer->base, wlr_pointer->output_name);
+	if (seat->server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST) {
+		map_input_device_to_first_enabled_output(seat, &wlr_pointer->base);
+	} else {
+		map_input_device_to_output(seat, &wlr_pointer->base, wlr_pointer->output_name);
+	}
 }
 
 static void
@@ -965,4 +987,18 @@ seat_center_cursor(struct cg_seat *seat)
 	struct wlr_box layout_box;
 	wlr_output_layout_get_box(seat->server->output_layout, NULL, &layout_box);
 	wlr_cursor_warp(seat->cursor, NULL, layout_box.width / 2, layout_box.height / 2);
+}
+
+void
+seat_remap_inputs_to_first_enabled_output(struct cg_seat *seat)
+{
+	/* Remap the input devices to the first enabled output device. */
+	struct cg_pointer *pointer;
+	wl_list_for_each (pointer, &seat->pointers, link) {
+		map_input_device_to_first_enabled_output(seat, &pointer->pointer->base);
+	}
+	struct cg_touch *touch;
+	wl_list_for_each (touch, &seat->touch, link) {
+		map_input_device_to_first_enabled_output(seat, &touch->touch->base);
+	}
 }

--- a/seat.h
+++ b/seat.h
@@ -92,5 +92,6 @@ void seat_destroy(struct cg_seat *seat);
 struct cg_view *seat_get_focus(struct cg_seat *seat);
 void seat_set_focus(struct cg_seat *seat, struct cg_view *view);
 void seat_center_cursor(struct cg_seat *seat);
+void seat_remap_inputs_to_first_enabled_output(struct cg_seat *seat);
 
 #endif


### PR DESCRIPTION
I'm not certain if this is something you will want to merge as-is, but it was a useful patch for us to resolve issues with touch input devices which do not report which display out they map to.

In our situation we run with `-m last`, so there is only ever a single enabled display. This PR detects this situation and automatically maps the touch and pointer inputs to this enabled display.

This avoids the need for pre-configuring this using udev rules (I beleive [this is considered deprecated](https://github.com/cage-kiosk/cage/issues/324#issuecomment-1997409559) anyway?) and allows Cage to automatically work with any touch input device and output display automatically.

I have made sure this works both when the input devices are signalled as added before the outputs and when either the inputs or outputs change.

Related to #243.

Similar in idea to #167 and #193.