### PR TITLE
Add -S to set display socket name; avoid auto wayland-0

### DIFF
--- a/server.h
+++ b/server.h
@@ -66,6 +66,8 @@ struct cg_server {
 	bool return_app_code;
 	bool terminated;
 	enum wlr_log_importance log_level;
+
+	char *socket;
 };
 
 void server_terminate(struct cg_server *server);


### PR DESCRIPTION
Being able to set the socket name helps with having a predictable name when for example connecting wayvnc to it.

Not trying the socket name "wayland-0" seems to be best practice: https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/486