### PR TITLE
Allow to set app id from command line

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -233,6 +233,7 @@ usage(FILE *file, const char *cage)
 		" -m last Use only the last connected output\n"
 		" -s\t Allow VT switching\n"
 		" -v\t Show the version number and exit\n"
+		" -i app-id Set application idendifier for the toplevel window\n"
 		"\n"
 		" Use -- when you want to pass arguments to APPLICATION\n",
 		cage);
@@ -242,7 +243,7 @@ static bool
 parse_args(struct cg_server *server, int argc, char *argv[])
 {
 	int c;
-	while ((c = getopt(argc, argv, "dDhm:sv")) != -1) {
+	while ((c = getopt(argc, argv, "dDhm:svi:")) != -1) {
 		switch (c) {
 		case 'd':
 			server->xdg_decoration = true;
@@ -262,6 +263,9 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 			break;
 		case 's':
 			server->allow_vt_switch = true;
+			break;
+		case 'i':
+			server->app_id = optarg;
 			break;
 		case 'v':
 			fprintf(stdout, "Cage version " CAGE_VERSION "\n");

--- a/output.c
+++ b/output.c
@@ -272,6 +272,10 @@ handle_new_output(struct wl_listener *listener, void *data)
 		return;
 	}
 
+	if (server->app_id != NULL && wlr_output_is_wl(wlr_output)) {
+		wlr_wl_output_set_app_id(wlr_output, server->app_id);
+	}
+
 	output->wlr_output = wlr_output;
 	wlr_output->data = output;
 	output->server = server;

--- a/server.h
+++ b/server.h
@@ -66,6 +66,7 @@ struct cg_server {
 	bool return_app_code;
 	bool terminated;
 	enum wlr_log_importance log_level;
+	const char *app_id;
 };
 
 void server_terminate(struct cg_server *server);


### PR DESCRIPTION
Currently cage has "wlroots" as its app id. Add a flag to make it configurable.

My use-case : I want some cage instances to be floating, others not to be floating. This patch allows me to do that using `for_window` in sway config :

```
for_window {
        [app_id="cage:floating:.*"] floating enable
}
```

And running `cage -i cage:floating:xxx cmd`.