### PR TITLE
output: drop unused wlr_matrix.h include

### DIFF
--- a/output.c
+++ b/output.c
@@ -24,7 +24,6 @@
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_data_device.h>
-#include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output_management_v1.h>


### PR DESCRIPTION
This is dropped in the next wlroots release.