### PR TITLE
output: add "named" to multi-output-modes

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -231,6 +231,7 @@ usage(FILE *file, const char *cage)
 		" -h\t Display this help message\n"
 		" -m extend Extend the display across all connected outputs (default)\n"
 		" -m last Use only the last connected output\n"
+		" -m named Use the output specified by the environment CAGE_OUTPUT_NAME, or fallback to last\n"
 		" -s\t Allow VT switching\n"
 		" -v\t Show the version number and exit\n"
 		"\n"
@@ -258,6 +259,8 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 				server->output_mode = CAGE_MULTI_OUTPUT_MODE_LAST;
 			} else if (strcmp(optarg, "extend") == 0) {
 				server->output_mode = CAGE_MULTI_OUTPUT_MODE_EXTEND;
+			} else if (strcmp(optarg, "named") == 0) {
+				server->output_mode = CAGE_MULTI_OUTPUT_MODE_NAMED;
 			}
 			break;
 		case 's':

--- a/server.h
+++ b/server.h
@@ -18,6 +18,7 @@
 enum cg_multi_output_mode {
 	CAGE_MULTI_OUTPUT_MODE_EXTEND,
 	CAGE_MULTI_OUTPUT_MODE_LAST,
+	CAGE_MULTI_OUTPUT_MODE_NAMED,
 };
 
 struct cg_server {


### PR DESCRIPTION
Sometimes it is difficult to determine the order of multiple monitors, so use environment variable to specify the output.

It read `CAGE_OUTPUT_NAME` or fallback to the last mode.