### PR TITLE
xdg_shell: bump to v5

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -416,7 +416,7 @@ main(int argc, char *argv[])
 	wl_signal_add(&server.idle_inhibit_v1->events.new_inhibitor, &server.new_idle_inhibitor_v1);
 	wl_list_init(&server.inhibitors);
 
-	struct wlr_xdg_shell *xdg_shell = wlr_xdg_shell_create(server.wl_display, 4);
+	struct wlr_xdg_shell *xdg_shell = wlr_xdg_shell_create(server.wl_display, 5);
 	if (!xdg_shell) {
 		wlr_log(WLR_ERROR, "Unable to create the XDG shell interface");
 		ret = 1;

--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -227,6 +227,8 @@ handle_xdg_toplevel_commit(struct wl_listener *listener, void *data)
 		return;
 	}
 
+	wlr_xdg_toplevel_set_wm_capabilities(xdg_shell_view->xdg_toplevel, XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN);
+
 	/* When an xdg_surface performs an initial commit, the compositor must
 	 * reply with a configure so the client can map the surface. */
 	view_position(&xdg_shell_view->view);


### PR DESCRIPTION
v5 adds the wm_capabilities event. cage only supports fullscreen.