### PR TITLE
Add optional feature to notify status to systemd

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -2,6 +2,7 @@
 #define CG_CONFIG_H
 
 #mesondefine CAGE_HAS_XWAYLAND
+#mesondefine CAGE_HAS_SYSTEMD
 
 #mesondefine CAGE_VERSION
 

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ wlroots        = dependency('wlroots-0.19', fallback: ['wlroots', 'wlroots'])
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 wayland_server = dependency('wayland-server')
 xkbcommon      = dependency('xkbcommon')
+systemd        = dependency('libsystemd', required: get_option('systemd'))
 math           = cc.find_library('m')
 
 wl_protocol_dir = wayland_protos.get_variable('pkgdatadir')
@@ -82,6 +83,7 @@ endif
 
 conf_data = configuration_data()
 conf_data.set10('CAGE_HAS_XWAYLAND', have_xwayland)
+conf_data.set10('CAGE_HAS_SYSTEMD', systemd.found())
 conf_data.set_quoted('CAGE_VERSION', version)
 
 scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: get_option('man-pages'))
@@ -136,6 +138,10 @@ if conf_data.get('CAGE_HAS_XWAYLAND', 0) == 1
   cage_headers += 'xwayland.h'
 endif
 
+if conf_data.get('CAGE_HAS_SYSTEMD', 0) == 1
+  cage_sources += 'notify_systemd.c'
+endif
+
 executable(
   meson.project_name(),
   cage_sources + cage_headers,
@@ -144,6 +150,7 @@ executable(
     wayland_server,
     wlroots,
     xkbcommon,
+    systemd,
     math,
   ],
   install: true,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
+option('systemd', type: 'feature', value: 'disabled', description: 'Notify status to systemd')

--- a/notify.h
+++ b/notify.h
@@ -1,0 +1,24 @@
+#ifndef CG_NOTIFY_H
+#define CG_NOTIFY_H
+
+#include "config.h"
+
+#define CAGE_ALIVE_PERIOD_MS (20000)
+
+enum cg_notify_state {
+	CAGE_READY,
+	CAGE_ALIVE,
+	CAGE_STOPPING,
+};
+
+#if !CAGE_HAS_SYSTEMD
+static inline void
+notify_set_state(enum cg_notify_state state)
+{
+	/* Nothing */
+}
+#else
+void notify_set_state(enum cg_notify_state state);
+#endif
+
+#endif

--- a/notify_systemd.c
+++ b/notify_systemd.c
@@ -1,0 +1,33 @@
+/*
+ * Cage: A Wayland kiosk.
+ *
+ * Copyright (C) 2018-2020 Jente Hidskes
+ *
+ * See the LICENSE file accompanying this file.
+ */
+
+#include "config.h"
+
+#include <systemd/sd-daemon.h>
+
+#include "notify.h"
+
+void
+notify_set_state(enum cg_notify_state state)
+{
+	const char *sd_state;
+
+	switch (state) {
+	case CAGE_READY:
+		sd_state = "READY=1";
+		break;
+	case CAGE_ALIVE:
+		sd_state = "WATCHDOG=1";
+		break;
+	case CAGE_STOPPING:
+		sd_state = "STOPPING=1";
+		break;
+	}
+
+	sd_notify(0, sd_state);
+}

--- a/server.h
+++ b/server.h
@@ -66,6 +66,7 @@ struct cg_server {
 	bool return_app_code;
 	bool terminated;
 	enum wlr_log_importance log_level;
+	struct wl_event_source *alive_source;
 };
 
 void server_terminate(struct cg_server *server);


### PR DESCRIPTION
When enabled, the feature uses libsystemd to notify service manager about the following states:
- ready
- periodic alive ping (20s)
- stopping

It allows to use Cage in a systemd unit with following options:
```
Type=notify
WatchdogSec=30s
```