### PR TITLE
Add support for wlr-foreign-toplevel-management

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -24,6 +24,7 @@
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
+#include <wlr/types/wlr_foreign_toplevel_management_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_idle_notify_v1.h>
@@ -523,6 +524,13 @@ main(int argc, char *argv[])
 	server.relative_pointer_manager = wlr_relative_pointer_manager_v1_create(server.wl_display);
 	if (!server.relative_pointer_manager) {
 		wlr_log(WLR_ERROR, "Unable to create the relative pointer manager");
+		ret = 1;
+		goto end;
+	}
+
+	server.foreign_toplevel_manager = wlr_foreign_toplevel_manager_v1_create(server.wl_display);
+	if (!server.foreign_toplevel_manager) {
+		wlr_log(WLR_ERROR, "Unable to create the foreign toplevel manager");
 		ret = 1;
 		goto end;
 	}

--- a/server.h
+++ b/server.h
@@ -61,6 +61,8 @@ struct cg_server {
 
 	struct wlr_relative_pointer_manager_v1 *relative_pointer_manager;
 
+	struct wlr_foreign_toplevel_manager_v1 *foreign_toplevel_manager;
+
 	bool xdg_decoration;
 	bool allow_vt_switch;
 	bool return_app_code;

--- a/view.h
+++ b/view.h
@@ -32,6 +32,10 @@ struct cg_view {
 
 	enum cg_view_type type;
 	const struct cg_view_impl *impl;
+
+	struct wlr_foreign_toplevel_handle_v1 *foreign_toplevel_handle;
+	struct wl_listener request_activate;
+	struct wl_listener request_close;
 };
 
 struct cg_view_impl {
@@ -41,6 +45,7 @@ struct cg_view_impl {
 	bool (*is_transient_for)(struct cg_view *child, struct cg_view *parent);
 	void (*activate)(struct cg_view *view, bool activate);
 	void (*maximize)(struct cg_view *view, int output_width, int output_height);
+	void (*close)(struct cg_view *view);
 	void (*destroy)(struct cg_view *view);
 };
 


### PR DESCRIPTION
This PR introduces support for the **wlr-foreign-toplevel-management** protocol in Cage.

The protocol is especially useful in kiosk scenarios. In our use case, the system needs to run multiple windows (for example, a VNC remote connection window and a WebKit browser). We would like these windows to remain active simultaneously and allow a background daemon to handle requests to switch between them. This enables smoother workflows where the remote connection window and the browser can be freely toggled when messages arrive.

I also noticed related discussions in the following issues, where adding support for this protocol has been requested:
	•	https://github.com/cage-kiosk/cage/issues/99
	•	https://github.com/cage-kiosk/cage/issues/302
	•	https://github.com/cage-kiosk/cage/issues/391

This implementation aims to address those needs by integrating the protocol directly into Cage.