### PR TITLE
output: disable output autoconfig if we got a wlr-output-management client

### DIFF
--- a/output.h
+++ b/output.h
@@ -18,6 +18,14 @@ struct cg_output {
 	struct wl_listener frame;
 
 	struct wl_list link; // cg_server::outputs
+
+	struct wl_list pending_autoconfigures; // cg_output_pending_autoconfigure::link
+};
+
+struct cg_output_pending_autoconfigure {
+	struct cg_output *output;
+	struct wl_listener resource_destroy;
+	struct wl_list link; // cg_output::pending_configures
 };
 
 void handle_output_manager_apply(struct wl_listener *listener, void *data);


### PR DESCRIPTION
When a daemon such as kanshi is connected, we don't want to auto-configure the output in such a way that the daemon would need to undo. Fix this by disabling output auto-configuration while a wlr-output-management client is connected.

This has two outstanding issues:

- Some wlr-output-management clients just monitor changes without being responsible for configuring outputs (e.g. wdisplays running in the background).
- kanshi will not set fields unless the user has explicitly configured them, so we can end up with an enabled output without a mode.