### PR TITLE
Fix segfault when title or app_id is NULL

### DIFF
--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -225,8 +225,12 @@ handle_xdg_toplevel_map(struct wl_listener *listener, void *data)
 
 	view_map(view, xdg_shell_view->xdg_toplevel->base->surface);
 
-	wlr_foreign_toplevel_handle_v1_set_title(view->foreign_toplevel_handle, xdg_shell_view->xdg_toplevel->title);
-	wlr_foreign_toplevel_handle_v1_set_app_id(view->foreign_toplevel_handle, xdg_shell_view->xdg_toplevel->app_id);
+	if (xdg_shell_view->xdg_toplevel->title)
+		wlr_foreign_toplevel_handle_v1_set_title(view->foreign_toplevel_handle,
+							 xdg_shell_view->xdg_toplevel->title);
+	if (xdg_shell_view->xdg_toplevel->app_id)
+		wlr_foreign_toplevel_handle_v1_set_app_id(view->foreign_toplevel_handle,
+							  xdg_shell_view->xdg_toplevel->app_id);
 	/* Activation state will be set by seat_set_focus */
 }
 

--- a/xwayland.c
+++ b/xwayland.c
@@ -142,9 +142,12 @@ handle_xwayland_surface_map(struct wl_listener *listener, void *data)
 
 	view_map(view, xwayland_view->xwayland_surface->surface);
 
-	wlr_foreign_toplevel_handle_v1_set_title(view->foreign_toplevel_handle, xwayland_view->xwayland_surface->title);
-	wlr_foreign_toplevel_handle_v1_set_app_id(view->foreign_toplevel_handle,
-						  xwayland_view->xwayland_surface->class);
+	if (xwayland_view->xwayland_surface->title)
+		wlr_foreign_toplevel_handle_v1_set_title(view->foreign_toplevel_handle,
+							 xwayland_view->xwayland_surface->title);
+	if (xwayland_view->xwayland_surface->class)
+		wlr_foreign_toplevel_handle_v1_set_app_id(view->foreign_toplevel_handle,
+							  xwayland_view->xwayland_surface->class);
 }
 
 static void


### PR DESCRIPTION
reproduce: run vkcube

stacktrace:

```
(gdb) bt
#0  0x0000778f43a8fd9c in __strlen_evex () from /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/libc.so.6
#1  0x0000778f439b0e93 in strdup () from /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/libc.so.6
#2  0x0000778f43c04932 in wlr_foreign_toplevel_handle_v1_set_app_id () from /nix/store/g0kgs3vprlzmgzig2371j3308y1xnf2z-wlroots-0.19.2/lib/libwlroots-0.19.so
#3  0x00005684811215fd in handle_xdg_toplevel_map (listener=0x5684c0eb2228, data=<optimized out>) at ../xdg_shell.c:229
#4  0x0000778f43caad4c in wl_signal_emit_mutable () from /nix/store/h9grlk1b07l80k6rnmyliawg25bdpsv5-wayland-1.24.0/lib/libwayland-server.so.0
#5  0x0000778f43bfd549 in surface_commit_state () from /nix/store/g0kgs3vprlzmgzig2371j3308y1xnf2z-wlroots-0.19.2/lib/libwlroots-0.19.so
#6  0x0000778f4368d052 in ffi_call_unix64 () from /nix/store/b9p0zpa93hwvh4d0r1rmgc2500yx2ldn-libffi-3.5.2/lib/libffi.so.8
#7  0x0000778f4368b60d in ffi_call_int () from /nix/store/b9p0zpa93hwvh4d0r1rmgc2500yx2ldn-libffi-3.5.2/lib/libffi.so.8
#8  0x0000778f4368c5ae in ffi_call () from /nix/store/b9p0zpa93hwvh4d0r1rmgc2500yx2ldn-libffi-3.5.2/lib/libffi.so.8
#9  0x0000778f43cafabf in wl_closure_invoke () from /nix/store/h9grlk1b07l80k6rnmyliawg25bdpsv5-wayland-1.24.0/lib/libwayland-server.so.0
#10 0x0000778f43ca9dd6 in wl_client_connection_data () from /nix/store/h9grlk1b07l80k6rnmyliawg25bdpsv5-wayland-1.24.0/lib/libwayland-server.so.0
#11 0x0000778f43cad1c2 in wl_event_loop_dispatch () from /nix/store/h9grlk1b07l80k6rnmyliawg25bdpsv5-wayland-1.24.0/lib/libwayland-server.so.0
#12 0x0000778f43caa6d5 in wl_display_run () from /nix/store/h9grlk1b07l80k6rnmyliawg25bdpsv5-wayland-1.24.0/lib/libwayland-server.so.0
#13 0x000056848111dd65 in main (argc=6, argv=0x7ffd6fd59f88) at ../cage.c:622
```