### PR TITLE
Drop -m flag

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -230,8 +230,6 @@ usage(FILE *file, const char *cage)
 		" -d\t Don't draw client side decorations, when possible\n"
 		" -D\t Enable debug logging\n"
 		" -h\t Display this help message\n"
-		" -m extend Extend the display across all connected outputs (default)\n"
-		" -m last Use only the last connected output\n"
 		" -s\t Allow VT switching\n"
 		" -v\t Show the version number and exit\n"
 		"\n"
@@ -243,7 +241,7 @@ static bool
 parse_args(struct cg_server *server, int argc, char *argv[])
 {
 	int c;
-	while ((c = getopt(argc, argv, "dDhm:sv")) != -1) {
+	while ((c = getopt(argc, argv, "dDhsv")) != -1) {
 		switch (c) {
 		case 'd':
 			server->xdg_decoration = true;
@@ -254,13 +252,6 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 		case 'h':
 			usage(stdout, argv[0]);
 			return false;
-		case 'm':
-			if (strcmp(optarg, "last") == 0) {
-				server->output_mode = CAGE_MULTI_OUTPUT_MODE_LAST;
-			} else if (strcmp(optarg, "extend") == 0) {
-				server->output_mode = CAGE_MULTI_OUTPUT_MODE_EXTEND;
-			}
-			break;
 		case 's':
 			server->allow_vt_switch = true;
 			break;

--- a/server.h
+++ b/server.h
@@ -15,11 +15,6 @@
 #include <wlr/xwayland.h>
 #endif
 
-enum cg_multi_output_mode {
-	CAGE_MULTI_OUTPUT_MODE_EXTEND,
-	CAGE_MULTI_OUTPUT_MODE_LAST,
-};
-
 struct cg_server {
 	struct wl_display *wl_display;
 	struct wl_list views;
@@ -35,7 +30,6 @@ struct cg_server {
 	struct wl_listener new_idle_inhibitor_v1;
 	struct wl_list inhibitors;
 
-	enum cg_multi_output_mode output_mode;
 	struct wlr_output_layout *output_layout;
 	struct wlr_scene_output_layout *scene_output_layout;
 


### PR DESCRIPTION
Tools can make use of the wlr-output-management-v1 protocol to configure outputs. Let's drop the "last" special case and leave all of the output configuration up to an external tool.