### PR TITLE
Add option to disable mouse input

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -241,6 +241,7 @@ usage(FILE *file, const char *cage)
 	fprintf(file,
 		"Usage: %s [OPTIONS] [--] [APPLICATION...]\n"
 		"\n"
+		" -c\t Disable mouse input, and hide the cursor\n"
 		" -d\t Don't draw client side decorations, when possible\n"
 		" -D\t Enable debug logging\n"
 		" -h\t Display this help message\n"
@@ -257,8 +258,11 @@ static bool
 parse_args(struct cg_server *server, int argc, char *argv[])
 {
 	int c;
-	while ((c = getopt(argc, argv, "dDhm:sv")) != -1) {
+	while ((c = getopt(argc, argv, "cdDhm:sv")) != -1) {
 		switch (c) {
+		case 'c':
+			server->disable_mouse = true;
+			break;
 		case 'd':
 			server->xdg_decoration = true;
 			break;

--- a/seat.c
+++ b/seat.c
@@ -118,7 +118,7 @@ update_capabilities(struct cg_seat *seat)
 	if (!wl_list_empty(&seat->keyboard_groups)) {
 		caps |= WL_SEAT_CAPABILITY_KEYBOARD;
 	}
-	if (!wl_list_empty(&seat->pointers)) {
+	if (!wl_list_empty(&seat->pointers) && !seat->server->disable_mouse) {
 		caps |= WL_SEAT_CAPABILITY_POINTER;
 	}
 	if (!wl_list_empty(&seat->touch)) {

--- a/server.h
+++ b/server.h
@@ -70,6 +70,7 @@ struct cg_server {
 
 	struct wlr_foreign_toplevel_manager_v1 *foreign_toplevel_manager;
 
+	bool disable_mouse;
 	bool xdg_decoration;
 	bool allow_vt_switch;
 	bool return_app_code;


### PR DESCRIPTION
# Add option to disable mouse input
Occasionally cage detects a non-existent mouse, or falsely identifies another device as a mouse.
Or sometimes you might want to disable the mouse cursor, even when there is a mouse connected.

Since there doesn't seem to be a solution to these issues yet, I've added a command-line option (`-c`),
which disables mouse input completely, and thereby also hides the cursor.
Touch input still works, with this option.

I am not super familiar with the cage codebase yet, so someone who knows what they're doing should
take a closer look, and decide if this is a viable solution.