### PR TITLE
fix segfault when exitting cage with a child still present

### DIFF
--- a/view.c
+++ b/view.c
@@ -112,17 +112,31 @@ view_position_all(struct cg_server *server)
 	}
 }
 
+static void
+handle_surface_destroy(struct wl_listener *listener, void *data)
+{
+	struct cg_view *view = wl_container_of(listener, view, surface_destroy);
+	/* wlroots is about to free scene_tree via the subsurface tree listener
+	 * (registered before us). Null it out so view_unmap() skips the destroy. */
+	view->scene_tree = NULL;
+}
+
 void
 view_unmap(struct cg_view *view)
 {
 	wl_list_remove(&view->link);
+	/* Always registered in view_map() before any unmap can fire. */
+	wl_list_remove(&view->surface_destroy.link);
 
 	wl_list_remove(&view->request_activate.link);
 	wl_list_remove(&view->request_close.link);
 	wlr_foreign_toplevel_handle_v1_destroy(view->foreign_toplevel_handle);
 	view->foreign_toplevel_handle = NULL;
 
-	wlr_scene_node_destroy(&view->scene_tree->node);
+	if (view->scene_tree) {
+		wlr_scene_node_destroy(&view->scene_tree->node);
+		view->scene_tree = NULL;
+	}
 
 	view->wlr_surface->data = NULL;
 	view->wlr_surface = NULL;
@@ -151,6 +165,12 @@ view_map(struct cg_view *view, struct wlr_surface *surface)
 	if (!view->scene_tree)
 		goto fail;
 	view->scene_tree->node.data = view;
+
+	/* Register after wlr_scene_subsurface_tree_create() so our listener fires
+	 * after wlroots' internal one, which frees scene_tree on surface destroy.
+	 * This lets us null scene_tree before view_unmap() tries to use it. */
+	view->surface_destroy.notify = handle_surface_destroy;
+	wl_signal_add(&surface->events.destroy, &view->surface_destroy);
 
 	view->wlr_surface = surface;
 	surface->data = view;

--- a/view.h
+++ b/view.h
@@ -26,6 +26,7 @@ struct cg_view {
 	struct wl_list link; // server::views
 	struct wlr_surface *wlr_surface;
 	struct wlr_scene_tree *scene_tree;
+	struct wl_listener surface_destroy; /* nullifies scene_tree when wlroots frees it */
 
 	/* The view has a position in layout coordinates. */
 	int lx, ly;


### PR DESCRIPTION
I encountered a SEGFAULT when running a program that had bad cleanup handling. ie: it was spawning child processes that owned the (xwayland-based) window and on SIGINT was exitting before the child had time to exit properly. I hacked-together a bash program that can reproduce the behaviour :

<details>

<summary>trigger SIGSEGV with xclock - bash script</summary>

```bash
#!/usr/bin/env bash
# Minimal reproducer for cage XWayland surface destroy crash.
#
# This script sends SIGTERM only to cage, leaving xclock alive so the
# surface is still present when wlr_xwayland_destroy() is called.
#
# Usage:
#   ./reproduce_crash.sh [path-to-cage]
#
# Expected result with unfixed cage:  exit code 139 (SIGSEGV)
# Expected result with fixed cage:    exit code 0

set -euo pipefail

CAGE=${1:-./build/cage}

if ! command -v xclock &>/dev/null; then
    echo "ERROR: xclock not found. Install with: sudo apt install x11-apps" >&2
    exit 1
fi

if [[ ! -x "$CAGE" ]]; then
    echo "ERROR: cage binary not found at $CAGE" >&2
    exit 1
fi

echo "Starting cage with xclock..."
"$CAGE" -- xclock &
CAGE_PID=$!

echo "Waiting for xclock to map its window..."
sleep 3

echo "Sending SIGTERM to cage (pid $CAGE_PID) only, xclock stays alive..."
kill -TERM "$CAGE_PID" 2>/dev/null || true

wait "$CAGE_PID"
EXIT=$?

if [[ $EXIT -eq 139 ]]; then
    echo "CRASHED (exit 139, SIGSEGV) — bug reproduced"
elif [[ $EXIT -eq 0 ]]; then
    echo "Clean exit (exit 0) — bug not present or already fixed"
else
    echo "Exited with code $EXIT"
fi
```

</details>

This is not a very high-profile bug, because a program that handles signals properly wouldn't trigger it. And it's triggered on exit anyways so it's only a minor inconvenience.

But I suppose it can't hurt to make destroy handlers a bit more robust? Anyways, I hope this helps.

The proposed fix registers a handler to nullify `scene_tree` after wlroots destroys the surface. cage's destroy handler is then made conditional to prevent dereferencing the destroyed tree node.

Please let me know if I misunderstood something or if the fix is otherwise problematic: I'm still new to wlroots.
