### PR TITLE
Make seat configurable via XDG_SEAT

### DIFF
--- a/seat.c
+++ b/seat.c
@@ -816,9 +816,10 @@ seat_create(struct cg_server *server, struct wlr_backend *backend)
 		return NULL;
 	}
 
-	seat->seat = wlr_seat_create(server->wl_display, "seat0");
+	const char *seat_name = getenv("XDG_SEAT") ?: "seat0";
+	seat->seat = wlr_seat_create(server.wl_display, seat_name);
 	if (!seat->seat) {
-		wlr_log(WLR_ERROR, "Cannot allocate seat0");
+		wlr_log(WLR_ERROR, "Cannot allocate %s", seat_name);
 		free(seat);
 		return NULL;
 	}

--- a/seat.c
+++ b/seat.c
@@ -816,7 +816,7 @@ seat_create(struct cg_server *server, struct wlr_backend *backend)
 		return NULL;
 	}
 
-	const char *seat_name = getenv("XDG_SEAT") ?: "seat0";
+	const char *seat_name = getenv("CAGE_SEAT") ?: "seat0";
 	seat->seat = wlr_seat_create(server.wl_display, seat_name);
 	if (!seat->seat) {
 		wlr_log(WLR_ERROR, "Cannot allocate %s", seat_name);


### PR DESCRIPTION
Hi @all,

This patch make the seat for cage to use configurable by the XDG standard variable XDG_SEAT for seat assignment. If this variable is not found it will fallback to seat0 which is the way it works now. 

In case you think this is to intrusive the variable name can also be full custom one like CAGE_SEAT or so.

The use case I made this patch for was running cage on a different seat then the default seat0 which has all hardware assigned by default to be compatible with systems without seat management at all. So i created a "seat-1", let cage run on it and only assigned the input devices (in my case this was only a touchscreen) and the DRM device (in my case a etnaviv gpu + ipu) for showing the wayland surface.

Greetings,
André