### PR TITLE
seat: change default seat name to "default" from "seat0"

### DIFF
--- a/seat.c
+++ b/seat.c
@@ -816,9 +816,9 @@ seat_create(struct cg_server *server, struct wlr_backend *backend)
 		return NULL;
 	}
 
-	seat->seat = wlr_seat_create(server->wl_display, "seat0");
+	seat->seat = wlr_seat_create(server->wl_display, "default");
 	if (!seat->seat) {
-		wlr_log(WLR_ERROR, "Cannot allocate seat0");
+		wlr_log(WLR_ERROR, "Cannot allocate seat");
 		free(seat);
 		return NULL;
 	}


### PR DESCRIPTION
"seat0" is confusing because it's the name used by logind for physical seats. Logical Wayland seats are completely orthogonal to login physical seats, so let's switch the name to reduce mixups a bit.

See the discussion in https://github.com/cage-kiosk/cage/pull/497