### PR TITLE
cage: advertise xdg-decoration-v1 version 2

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -450,7 +450,7 @@ main(int argc, char *argv[])
 	wl_signal_add(&xdg_shell->events.new_popup, &server.new_xdg_popup);
 
 	struct wlr_xdg_decoration_manager_v1 *xdg_decoration_manager =
-		wlr_xdg_decoration_manager_v1_create(server.wl_display);
+		wlr_xdg_decoration_manager_v1_create(server.wl_display, 2);
 	if (!xdg_decoration_manager) {
 		wlr_log(WLR_ERROR, "Unable to create the XDG decoration manager");
 		ret = 1;


### PR DESCRIPTION
Depends on this commit: https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/bd99e8c2bd077251e8fe1f21ed5ed2ddb92c9cf0. So this PR will presumably have to wait for wlroots 0.21.

Closes: https://github.com/cage-kiosk/cage/issues/509.
