### PR TITLE
Gracefully terminate clients

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -198,8 +198,22 @@ cleanup_primary_client(pid_t pid)
 {
 	int status;
 
+	wlr_log(WLR_DEBUG, "Sending SIGTERM to child with pid %d", pid);
+	kill(pid, SIGTERM);
+
+	/* 10 sec timeout with 100ms intervals */
+	for(int i = 0; i < 100; i++) {
+		if(waitpid(pid, &status, WNOHANG) > 0) {
+			goto done;
+		}
+		usleep(100000);
+	}
+
+	wlr_log(WLR_INFO, "Child did not exit after 10s, sending SIGKILL");
+	kill(pid, SIGKILL);
 	waitpid(pid, &status, 0);
 
+done:
 	if (WIFEXITED(status)) {
 		wlr_log(WLR_DEBUG, "Child exited normally with exit status %d", WEXITSTATUS(status));
 		return WEXITSTATUS(status);
@@ -655,6 +669,14 @@ main(int argc, char *argv[])
 	seat_center_cursor(server.seat);
 	wl_display_run(server.wl_display);
 
+	if (pid != 0) {
+		app_ret = cleanup_primary_client(pid);
+	}
+
+	if (!ret && server.return_app_code) {
+		ret = app_ret;
+	}
+
 #if CAGE_HAS_XWAYLAND
 	if (xwayland) {
 		wl_list_remove(&server.new_xwayland_surface.link);
@@ -680,11 +702,6 @@ main(int argc, char *argv[])
 	wl_list_remove(&server.output_layout_change.link);
 
 end:
-	if (pid != 0)
-		app_ret = cleanup_primary_client(pid);
-	if (!ret && server.return_app_code)
-		ret = app_ret;
-
 	wl_event_source_remove(sigint_source);
 	wl_event_source_remove(sigterm_source);
 	if (sigchld_source) {

--- a/cage.c
+++ b/cage.c
@@ -201,12 +201,15 @@ cleanup_primary_client(pid_t pid)
 	wlr_log(WLR_DEBUG, "Sending SIGTERM to child with pid %d", pid);
 	kill(pid, SIGTERM);
 
+	/* 100 ms in nanoseconds */
+	struct timespec ts = {0, 100000000};
+
 	/* 10 sec timeout with 100ms intervals */
 	for(int i = 0; i < 100; i++) {
 		if(waitpid(pid, &status, WNOHANG) > 0) {
 			goto done;
 		}
-		usleep(100000);
+		nanosleep(&ts, NULL);
 	}
 
 	wlr_log(WLR_INFO, "Child did not exit after 10s, sending SIGKILL");


### PR DESCRIPTION
Hi,

So I've been observing this kind of issue for a long time. At $work, we're running an Electron kiosk app as cage program, and when cage service is stopped by systemd, Electron often dies abruptly, as Wayland socket is already gone by the time it gets a signal.

This change should allow graceful termination (10 secs might be too long, not sure if that has to be made configurable) and also ensure that Wayland socket is closed after program is done.