### PR TITLE
Add -r flag to rotate outputs

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -18,6 +18,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <wayland-server-core.h>
+#include <wayland-server-protocol.h>
 #include <wlr/backend.h>
 #include <wlr/config.h>
 #include <wlr/render/allocator.h>
@@ -246,6 +247,7 @@ usage(FILE *file, const char *cage)
 		" -h\t Display this help message\n"
 		" -m extend Extend the display across all connected outputs (default)\n"
 		" -m last Use only the last connected output\n"
+		" -r 0|90|180|270  Rotate the output (default: 0)\n"
 		" -s\t Allow VT switching\n"
 		" -v\t Show the version number and exit\n"
 		" -x\t Disable XWayland\n"
@@ -260,7 +262,7 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 	server->enable_xwayland = true;
 
 	int c;
-	while ((c = getopt(argc, argv, "dDhm:svx")) != -1) {
+	while ((c = getopt(argc, argv, "dDhm:r:svx")) != -1) {
 		switch (c) {
 		case 'd':
 			server->xdg_decoration = true;
@@ -276,6 +278,21 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 				server->output_mode = CAGE_MULTI_OUTPUT_MODE_LAST;
 			} else if (strcmp(optarg, "extend") == 0) {
 				server->output_mode = CAGE_MULTI_OUTPUT_MODE_EXTEND;
+			}
+			break;
+		case 'r':
+			if (strcmp(optarg, "0") == 0) {
+				server->output_rotation = WL_OUTPUT_TRANSFORM_NORMAL;
+			} else if (strcmp(optarg, "90") == 0) {
+				server->output_rotation = WL_OUTPUT_TRANSFORM_90;
+			} else if (strcmp(optarg, "180") == 0) {
+				server->output_rotation = WL_OUTPUT_TRANSFORM_180;
+			} else if (strcmp(optarg, "270") == 0) {
+				server->output_rotation = WL_OUTPUT_TRANSFORM_270;
+			} else {
+				fprintf(stderr, "Invalid rotation '%s'. Expected one of: 0, 90, 180, 270.\n", optarg);
+				usage(stderr, argv[0]);
+				return false;
 			}
 			break;
 		case 's':

--- a/output.c
+++ b/output.c
@@ -281,6 +281,7 @@ handle_new_output(struct wl_listener *listener, void *data)
 
 	struct wlr_output_state state = {0};
 	wlr_output_state_set_enabled(&state, true);
+	wlr_output_state_set_transform(&state, server->output_rotation);
 	if (!wl_list_empty(&wlr_output->modes)) {
 		struct wlr_output_mode *preferred_mode = wlr_output_preferred_mode(wlr_output);
 		if (preferred_mode) {

--- a/server.h
+++ b/server.h
@@ -4,6 +4,7 @@
 #include "config.h"
 
 #include <wayland-server-core.h>
+#include <wayland-server-protocol.h>
 #include <wlr/config.h>
 #include <wlr/types/wlr_drm_lease_v1.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
@@ -73,6 +74,7 @@ struct cg_server {
 	bool xdg_decoration;
 	bool allow_vt_switch;
 	bool enable_xwayland;
+	enum wl_output_transform output_rotation;
 	bool return_app_code;
 	bool terminated;
 	enum wlr_log_importance log_level;


### PR DESCRIPTION
Was working on a DIY project where the layout required mounting the display rotated which lead me to this commit..

While this was initially made for my own problem.. figured others might find it useful.

This adds an `output_rotation` field to `struct cg_server` to store the output and used via `wlr_output_state_set_transform()`.

The flag supports `0`, `90`, `180`, and `270` rotations.

```bash
cage -r 90 -- ghostty
```