### PR TITLE
Add -C flag to hide the cursor

### DIFF
--- a/cage.1.scd
+++ b/cage.1.scd
@@ -16,6 +16,9 @@ activities outside the scope of the running application are prevented.
 
 # OPTIONS
 
+*-C*
+	Hide the cursor.
+
 *-d*
 	Don't draw client side decorations when possible.
 

--- a/cage.c
+++ b/cage.c
@@ -259,6 +259,7 @@ usage(FILE *file, const char *cage)
 	fprintf(file,
 		"Usage: %s [OPTIONS] [--] [APPLICATION...]\n"
 		"\n"
+		" -C\t Hide the cursor\n"
 		" -d\t Don't draw client side decorations, when possible\n"
 		" -D\t Enable debug logging\n"
 		" -h\t Display this help message\n"
@@ -278,8 +279,11 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 	server->enable_xwayland = true;
 
 	int c;
-	while ((c = getopt(argc, argv, "dDhm:svx")) != -1) {
+	while ((c = getopt(argc, argv, "CdDhm:svx")) != -1) {
 		switch (c) {
+		case 'C':
+			server->hide_cursor = true;
+			break;
 		case 'd':
 			server->xdg_decoration = true;
 			break;

--- a/seat.c
+++ b/seat.c
@@ -125,8 +125,9 @@ update_capabilities(struct cg_seat *seat)
 	}
 	wlr_seat_set_capabilities(seat->seat, caps);
 
-	/* Hide cursor if the seat doesn't have pointer capability. */
-	if ((caps & WL_SEAT_CAPABILITY_POINTER) == 0) {
+	/* Hide cursor if the seat doesn't have pointer capability, or if the
+	 * cursor was explicitly hidden by the user. */
+	if (seat->server->hide_cursor || (caps & WL_SEAT_CAPABILITY_POINTER) == 0) {
 		wlr_cursor_unset_image(seat->cursor);
 	} else {
 		wlr_cursor_set_xcursor(seat->cursor, seat->server->xcursor_manager, DEFAULT_XCURSOR);
@@ -487,6 +488,10 @@ handle_request_set_cursor(struct wl_listener *listener, void *data)
 	struct wl_client *focused_client = NULL;
 	if (has_focused) {
 		focused_client = wl_resource_get_client(focused_surface->resource);
+	}
+
+	if (seat->server->hide_cursor) {
+		return;
 	}
 
 	/* This can be sent by any client, so we check to make sure

--- a/server.h
+++ b/server.h
@@ -75,6 +75,7 @@ struct cg_server {
 	bool xdg_decoration;
 	bool allow_vt_switch;
 	bool enable_xwayland;
+	bool hide_cursor;
 	bool return_app_code;
 	bool terminated;
 	enum wlr_log_importance log_level;


### PR DESCRIPTION
## Summary
- Adds a `-C` command-line flag that unconditionally hides the cursor for the lifetime of the compositor.
- Cursor stays hidden even if a pointer-capable device is detected (e.g. spurious HDMI-CEC/DRM pointer devices) and clients' `set_cursor` requests are ignored while the flag is set.
- Documents the new flag in `-h` usage output and `cage.1.scd`.

Addresses #299, where the current logic (hide cursor only when no pointer device is present) doesn't cover common kiosk cases: spurious pointer-capable devices showing up on some hardware, or users who simply never want a cursor regardless of connected devices.

## Test plan
- [ ] Build with meson/ninja and confirm `cage -C -- <app>` never shows a cursor, including when a pointer device is attached
- [ ] Confirm `cage -h` lists the new `-C` option
- [ ] Confirm existing behavior (cursor shown/hidden based on device capability) is unchanged when `-C` is not passed