### PR TITLE
seat: support cursor-shape-v1 protocol

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -23,6 +23,7 @@
 #include <wlr/render/allocator.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_compositor.h>
+#include <wlr/types/wlr_cursor_shape_v1.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
@@ -439,6 +440,16 @@ main(int argc, char *argv[])
 		goto end;
 	}
 
+	server.cursor_shape_manager_v1 = wlr_cursor_shape_manager_v1_create(server.wl_display, 2);
+	if (!server.cursor_shape_manager_v1) {
+		wlr_log(WLR_ERROR, "Unable to create cursor shape manager");
+		ret = 1;
+		goto end;
+	}
+	server.cursor_shape_manager_set_shape.notify = handle_request_set_shape;
+	wl_signal_add(&server.cursor_shape_manager_v1->events.request_set_shape,
+		      &server.cursor_shape_manager_set_shape);
+
 	server.seat = seat_create(&server, server.backend);
 	if (!server.seat) {
 		wlr_log(WLR_ERROR, "Unable to create the seat");
@@ -675,6 +686,7 @@ main(int argc, char *argv[])
 	wl_list_remove(&server.xdg_toplevel_decoration.link);
 	wl_list_remove(&server.new_xdg_toplevel.link);
 	wl_list_remove(&server.new_xdg_popup.link);
+	wl_list_remove(&server.cursor_shape_manager_set_shape.link);
 	wl_list_remove(&server.new_idle_inhibitor_v1.link);
 	wl_list_remove(&server.new_output.link);
 	wl_list_remove(&server.output_layout_change.link);

--- a/seat.c
+++ b/seat.c
@@ -19,6 +19,7 @@
 #include <wlr/backend/multi.h>
 #include <wlr/backend/session.h>
 #include <wlr/types/wlr_cursor.h>
+#include <wlr/types/wlr_cursor_shape_v1.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_keyboard_group.h>
@@ -29,6 +30,7 @@
 #include <wlr/types/wlr_touch.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_virtual_pointer_v1.h>
+#include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/util/log.h>
 #if CAGE_HAS_XWAYLAND
 #include <wlr/xwayland.h>
@@ -477,22 +479,44 @@ handle_request_set_selection(struct wl_listener *listener, void *data)
 	wlr_seat_set_selection(seat->seat, event->source, event->serial);
 }
 
-static void
-handle_request_set_cursor(struct wl_listener *listener, void *data)
+static bool
+client_has_pointer_focus(struct cg_seat *seat, struct wl_client *client)
 {
-	struct cg_seat *seat = wl_container_of(listener, seat, request_set_cursor);
-	struct wlr_seat_pointer_request_set_cursor_event *event = data;
-	struct wlr_surface *focused_surface = event->seat_client->seat->pointer_state.focused_surface;
+	struct wlr_surface *focused_surface = seat->seat->pointer_state.focused_surface;
 	bool has_focused = focused_surface != NULL && focused_surface->resource != NULL;
 	struct wl_client *focused_client = NULL;
 	if (has_focused) {
 		focused_client = wl_resource_get_client(focused_surface->resource);
 	}
 
+	return focused_client == client;
+}
+
+static void
+handle_request_set_cursor(struct wl_listener *listener, void *data)
+{
+	struct cg_seat *seat = wl_container_of(listener, seat, request_set_cursor);
+	struct wlr_seat_pointer_request_set_cursor_event *event = data;
+
 	/* This can be sent by any client, so we check to make sure
 	 * this one actually has pointer focus first. */
-	if (focused_client == event->seat_client->client) {
+	if (client_has_pointer_focus(seat, event->seat_client->client)) {
 		wlr_cursor_set_surface(seat->cursor, event->surface, event->hotspot_x, event->hotspot_y);
+	}
+}
+
+void
+handle_request_set_shape(struct wl_listener *listener, void *data)
+{
+	struct cg_server *server = wl_container_of(listener, server, cursor_shape_manager_set_shape);
+	struct cg_seat *seat = server->seat;
+	struct wlr_cursor_shape_manager_v1_request_set_shape_event *event = data;
+
+	/* This can be sent by any client, so we check to make sure
+	 * this one actually has pointer focus first. */
+	if (client_has_pointer_focus(seat, event->seat_client->client)) {
+		const char *shape_name = wlr_cursor_shape_v1_name(event->shape);
+		wlr_cursor_set_xcursor(seat->cursor, seat->server->xcursor_manager, shape_name);
 	}
 }
 

--- a/seat.h
+++ b/seat.h
@@ -91,4 +91,5 @@ struct cg_view *seat_get_focus(struct cg_seat *seat);
 void seat_set_focus(struct cg_seat *seat, struct cg_view *view);
 void seat_center_cursor(struct cg_seat *seat);
 
+void handle_request_set_shape(struct wl_listener *listener, void *data);
 #endif

--- a/server.h
+++ b/server.h
@@ -72,6 +72,9 @@ struct cg_server {
 
 	struct wlr_xcursor_manager *xcursor_manager;
 
+	struct wlr_cursor_shape_manager_v1 *cursor_shape_manager_v1;
+	struct wl_listener cursor_shape_manager_set_shape;
+
 	bool xdg_decoration;
 	bool allow_vt_switch;
 	bool enable_xwayland;


### PR DESCRIPTION
Adds support for [cursor-shape-v1 protocol](https://wayland.app/protocols/cursor-shape-v1) as suggested [here](https://github.com/cage-kiosk/cage/pull/494#issuecomment-4260547543)

We've been testing this using a Python GTK4 application and the xcursor themes are showing as expected, so we thought it might be worth upstreaming. That said, I noticed there  isn't actually a dedicated issue, so maybe you prefer to wait until the protocol is more stable?  Either way, I'm happy to make any changes if needs be.

Thanks for all the amazing work! z