### PR TITLE
output: add -o to use only a named output

### DIFF
--- a/cage.1.scd
+++ b/cage.1.scd
@@ -30,6 +30,11 @@ activities outside the scope of the running application are prevented.
 	*last* Cage uses only the last connected monitor.
 	*extend* Cage extends the display across all connected monitors.
 
+*-o* <name>
+	Use only the output with the given name, for example _DP-1_. All other
+	outputs are switched off. If no connected output matches, Cage exits with
+	an error. Overrides *-m*.
+
 *-s*
 	Allow VT switching
 

--- a/cage.c
+++ b/cage.c
@@ -265,6 +265,7 @@ usage(FILE *file, const char *cage)
 		" -h\t Display this help message\n"
 		" -m extend Extend the display across all connected outputs (default)\n"
 		" -m last Use only the last connected output\n"
+		" -o <name> Use only the output with this name, e.g. DP-1 (overrides -m)\n"
 		" -s\t Allow VT switching\n"
 		" -v\t Show the version number and exit\n"
 		" -x\t Disable XWayland\n"
@@ -279,7 +280,7 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 	server->enable_xwayland = true;
 
 	int c;
-	while ((c = getopt(argc, argv, "dDhm:svx")) != -1) {
+	while ((c = getopt(argc, argv, "dDhm:o:svx")) != -1) {
 		switch (c) {
 		case 'd':
 			server->xdg_decoration = true;
@@ -296,6 +297,13 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 			} else if (strcmp(optarg, "extend") == 0) {
 				server->output_mode = CAGE_MULTI_OUTPUT_MODE_EXTEND;
 			}
+			break;
+		case 'o':
+			if (optarg[0] == '\0') {
+				wlr_log(WLR_ERROR, "-o requires a non-empty output name");
+				return false;
+			}
+			server->output_name = optarg;
 			break;
 		case 's':
 			server->allow_vt_switch = true;
@@ -332,6 +340,10 @@ main(int argc, char *argv[])
 	}
 
 	wlr_log_init(server.log_level, NULL);
+
+	if (server.output_name && server.output_mode == CAGE_MULTI_OUTPUT_MODE_LAST) {
+		wlr_log(WLR_INFO, "-m last has no effect when -o is given");
+	}
 
 	/* Wayland requires XDG_RUNTIME_DIR to be set. */
 	if (!getenv("XDG_RUNTIME_DIR")) {
@@ -646,6 +658,12 @@ main(int argc, char *argv[])
 		goto end;
 	}
 
+	if (server.output_name && wl_list_empty(&server.outputs)) {
+		wlr_log(WLR_ERROR, "No connected output is named '%s'", server.output_name);
+		ret = 1;
+		goto teardown;
+	}
+
 	if (setenv("WAYLAND_DISPLAY", socket, true) < 0) {
 		wlr_log_errno(WLR_ERROR, "Unable to set WAYLAND_DISPLAY. Clients may not be able to connect");
 	} else {
@@ -665,6 +683,8 @@ main(int argc, char *argv[])
 
 	seat_center_cursor(server.seat);
 	wl_display_run(server.wl_display);
+
+teardown:
 
 #if CAGE_HAS_XWAYLAND
 	if (xwayland) {

--- a/output.c
+++ b/output.c
@@ -13,6 +13,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
@@ -214,7 +215,7 @@ output_destroy(struct cg_output *output)
 
 	free(output);
 
-	if (wl_list_empty(&server->outputs) && was_nested_output) {
+	if (wl_list_empty(&server->outputs) && (was_nested_output || server->output_name)) {
 		server_terminate(server);
 	} else if (server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST && !wl_list_empty(&server->outputs)) {
 		struct cg_output *prev = wl_container_of(server->outputs.next, prev, link);
@@ -243,6 +244,16 @@ handle_new_output(struct wl_listener *listener, void *data)
 			wlr_drm_lease_v1_manager_offer_output(server->drm_lease_v1, wlr_output);
 		}
 #endif
+		return;
+	}
+
+	if (server->output_name && strcmp(wlr_output->name, server->output_name) != 0) {
+		wlr_log(WLR_INFO, "Ignoring output '%s': -o selected '%s'", wlr_output->name, server->output_name);
+		if (wlr_output->enabled) {
+			struct wlr_output_state state = {0};
+			wlr_output_state_set_enabled(&state, false);
+			wlr_output_commit_state(wlr_output, &state);
+		}
 		return;
 	}
 

--- a/server.h
+++ b/server.h
@@ -38,6 +38,7 @@ struct cg_server {
 	struct wl_list inhibitors;
 
 	enum cg_multi_output_mode output_mode;
+	const char *output_name;
 	struct wlr_output_layout *output_layout;
 	struct wlr_scene_output_layout *scene_output_layout;
 


### PR DESCRIPTION
This PR adds a `-o <name>` flag that pins Cage to a single output, matched against the wlroots connector name (`DP-1`, `HDMI-A-1`, and so on). `-m last` already restricts Cage to one monitor, but which one you get depends on enumeration order, so there's currently no way to say which screen you actually want. That matters for kiosks and greeters that need to come up on a specific panel.

Excluded outputs get switched off rather than just skipped. The DRM backend hands them over already enabled, and if Cage never renders to one it will sit there scanning out whatever was in its framebuffer when Cage took DRM master, so on a greeter the previous session's last frame stays up next to the login prompt.

If no connected output matches the name, Cage now exits non-zero instead of running with an empty output list. The self-terminate path in `output_destroy()` is gated on `was_nested_output` and on an output having been registered first, so it can't catch this case, and the result today is a live compositor rendering nowhere with one INFO line to show for it.

Reaching that new exit turned up an assertion in `wlr_output_layout_destroy()`, because the listener teardown block only runs on the normal path. I added a `teardown:` label to unwind the same way. The earlier `goto end` sites are left alone since they run before those links are initialised.

Tested on the headless backend (`WLR_BACKENDS=headless WLR_HEADLESS_OUTPUTS=2`) for the matching, non-matching, empty-name, and `-o` with `-m last` combinations, and on a real DRM session with two DisplayPort monitors, where the selected output came up as expected and the excluded one went dark. Hotplug is untested.
