### PR TITLE
output: do not re-enable outputs while shutting down

### DIFF
--- a/output.c
+++ b/output.c
@@ -216,7 +216,8 @@ output_destroy(struct cg_output *output)
 
 	if (wl_list_empty(&server->outputs) && was_nested_output) {
 		server_terminate(server);
-	} else if (server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST && !wl_list_empty(&server->outputs)) {
+	} else if (server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST && !wl_list_empty(&server->outputs) &&
+		   !server->terminated) {
 		struct cg_output *prev = wl_container_of(server->outputs.next, prev, link);
 		output_enable(prev);
 		view_position_all(server);


### PR DESCRIPTION
With -m last, destroying an output re-enables the previous one. During wl_display_destroy() the output layout is torn down by the display destroy signal before the backend destroys its outputs, so the re-enable path in output_destroy() adds the previous output to an already freed layout and crashes on exit (see #515). server->terminated is already set from the display destroy listener, so skip the re-enable once it is set.

Fixes #515