### PR TITLE
seat: drop set_cursor requests when pointer capability is absent

### DIFF
--- a/seat.c
+++ b/seat.c
@@ -500,7 +500,8 @@ handle_request_set_cursor(struct wl_listener *listener, void *data)
 
 	/* This can be sent by any client, so we check to make sure
 	 * this one actually has pointer focus first. */
-	if (client_has_pointer_focus(seat, event->seat_client->client)) {
+	if (client_has_pointer_focus(seat, event->seat_client->client) &&
+	    (seat->seat->capabilities & WL_SEAT_CAPABILITY_POINTER) != 0) {
 		wlr_cursor_set_surface(seat->cursor, event->surface, event->hotspot_x, event->hotspot_y);
 	}
 }
@@ -514,7 +515,8 @@ handle_request_set_shape(struct wl_listener *listener, void *data)
 
 	/* This can be sent by any client, so we check to make sure
 	 * this one actually has pointer focus first. */
-	if (client_has_pointer_focus(seat, event->seat_client->client)) {
+	if (client_has_pointer_focus(seat, event->seat_client->client) &&
+	    (seat->seat->capabilities & WL_SEAT_CAPABILITY_POINTER) != 0) {
 		const char *shape_name = wlr_cursor_shape_v1_name(event->shape);
 		wlr_cursor_set_xcursor(seat->cursor, seat->server->xcursor_manager, shape_name);
 	}


### PR DESCRIPTION
When a pointer device is removed, cage calls wlr_cursor_unset_image() and broadcasts wl_seat.capabilities(0) to clients. However, because Wayland IPC is asynchronous, a client may legally send a lagging wl_pointer_set_cursor request before processing the revocation event.

Currently, handle_request_set_cursor and handle_request_set_shape only check if the client has focus, ignoring whether the seat actually still possesses the pointer capability. Because cage shares a single wlr_cursor object between touch and pointer devices, honoring this lagging request forcibly re-attaches the cursor surface, causing a permanent "ghost" cursor to get stranded on such displays.

This commit explicitly drops requests if the seat no longer has the WL_SEAT_CAPABILITY_POINTER flag.