### PR TITLE
Implement Pointer Constraints (zwp_pointer_constraints_v1)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,11 @@ jobs:
         run: |
           meson setup --fatal-meson-warnings --wrap-mode=nodownload \
             build-${{ matrix.CC }}-${{matrix.xwayland }} \
-            -Dwlroots:xwayland=${{ matrix.xwayland }}
+            -Dwlroots:xwayland=${{ matrix.xwayland }} -Dtests=enabled
           ninja -C build-${{ matrix.CC }}-${{matrix.xwayland }}
+
+      - name: Run tests
+        run: meson test -C build-${{ matrix.CC }}-${{matrix.xwayland }} --print-errorlogs
 
   format:
     runs-on: ubuntu-latest

--- a/cage.c
+++ b/cage.c
@@ -346,6 +346,28 @@ main(int argc, char *argv[])
 	}
 
 	wl_display_set_default_max_buffer_size(server.wl_display, 1024 * 1024);
+	/* The error paths below can be taken before any given listener has been
+	 * registered, and unlinking one that was never linked crashes. Keep the
+	 * links initialized so the teardown at the end can unlink them all
+	 * unconditionally: several protocol implementations assert an empty
+	 * listener list when the display is destroyed, and would abort rather
+	 * than let cage exit with an error. */
+	wl_list_init(&server.output_layout_change.link);
+	wl_list_init(&server.new_output.link);
+	wl_list_init(&server.cursor_shape_manager_set_shape.link);
+	wl_list_init(&server.new_idle_inhibitor_v1.link);
+	wl_list_init(&server.new_xdg_toplevel.link);
+	wl_list_init(&server.new_xdg_popup.link);
+	wl_list_init(&server.xdg_toplevel_decoration.link);
+	wl_list_init(&server.output_manager_apply.link);
+	wl_list_init(&server.output_manager_test.link);
+	wl_list_init(&server.new_virtual_keyboard.link);
+	wl_list_init(&server.new_virtual_pointer.link);
+	wl_list_init(&server.new_constraint.link);
+#if CAGE_HAS_XWAYLAND
+	wl_list_init(&server.new_xwayland_surface.link);
+#endif
+
 	server.display_destroy.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(server.wl_display, &server.display_destroy);
 
@@ -595,6 +617,15 @@ main(int argc, char *argv[])
 		goto end;
 	}
 
+	server.pointer_constraints = wlr_pointer_constraints_v1_create(server.wl_display);
+	if (!server.pointer_constraints) {
+		wlr_log(WLR_ERROR, "Unable to create the pointer constraints manager");
+		ret = 1;
+		goto end;
+	}
+	server.new_constraint.notify = handle_pointer_constraint;
+	wl_signal_add(&server.pointer_constraints->events.new_constraint, &server.new_constraint);
+
 	server.foreign_toplevel_manager = wlr_foreign_toplevel_manager_v1_create(server.wl_display);
 	if (!server.foreign_toplevel_manager) {
 		wlr_log(WLR_ERROR, "Unable to create the foreign toplevel manager");
@@ -667,13 +698,19 @@ main(int argc, char *argv[])
 	wl_display_run(server.wl_display);
 
 #if CAGE_HAS_XWAYLAND
-	if (xwayland) {
-		wl_list_remove(&server.new_xwayland_surface.link);
-	}
+	/* wlr_xwayland_destroy() asserts its new_surface listener list is empty,
+	 * so unlink ahead of it — and leave the link initialized for the
+	 * teardown below, which unlinks it again on the error paths. */
+	wl_list_remove(&server.new_xwayland_surface.link);
+	wl_list_init(&server.new_xwayland_surface.link);
 	wlr_xwayland_destroy(xwayland);
 #endif
 	wl_display_destroy_clients(server.wl_display);
 
+end:
+#if CAGE_HAS_XWAYLAND
+	wl_list_remove(&server.new_xwayland_surface.link);
+#endif
 #if WLR_HAS_DRM_BACKEND
 	if (server.drm_lease_v1) {
 		wl_list_remove(&server.drm_lease_request.link);
@@ -681,6 +718,7 @@ main(int argc, char *argv[])
 #endif
 	wl_list_remove(&server.new_virtual_pointer.link);
 	wl_list_remove(&server.new_virtual_keyboard.link);
+	wl_list_remove(&server.new_constraint.link);
 	wl_list_remove(&server.output_manager_apply.link);
 	wl_list_remove(&server.output_manager_test.link);
 	wl_list_remove(&server.xdg_toplevel_decoration.link);
@@ -691,7 +729,6 @@ main(int argc, char *argv[])
 	wl_list_remove(&server.new_output.link);
 	wl_list_remove(&server.output_layout_change.link);
 
-end:
 	if (pid != 0)
 		app_ret = cleanup_primary_client(pid);
 	if (!ret && server.return_app_code)

--- a/meson.build
+++ b/meson.build
@@ -107,7 +107,7 @@ if conf_data.get('CAGE_HAS_XWAYLAND', 0) == 1
   cage_sources += 'xwayland.c'
 endif
 
-executable(
+cage = executable(
   meson.project_name(),
   cage_sources,
   dependencies: [
@@ -120,11 +120,21 @@ executable(
   install: true,
 )
 
+tests_opt = get_option('tests')
+wayland_client = dependency('wayland-client', required: tests_opt)
+wayland_protos = dependency('wayland-protocols', version: '>=1.14', required: tests_opt)
+wayland_scanner = find_program('wayland-scanner', native: true, required: tests_opt)
+have_tests = wayland_client.found() and wayland_protos.found() and wayland_scanner.found()
+if have_tests
+  subdir('tests')
+endif
+
 summary = [
   '',
   'Cage @0@'.format(version),
   '',
   '    xwayland: @0@'.format(have_xwayland),
+  '    tests: @0@'.format(have_tests),
   ''
 ]
 message('\n'.join(summary))

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,7 @@ endif
 wlroots        = dependency('wlroots-0.20', fallback: ['wlroots', 'wlroots'])
 wayland_server = dependency('wayland-server')
 xkbcommon      = dependency('xkbcommon')
+pixman         = dependency('pixman-1')
 math           = cc.find_library('m')
 
 have_xwayland = wlroots.get_variable(pkgconfig: 'have_xwayland', internal: 'have_xwayland') == 'true'
@@ -113,6 +114,7 @@ executable(
     wayland_server,
     wlroots,
     xkbcommon,
+    pixman,
     math,
   ],
   install: true,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
+option('tests', type: 'feature', value: 'disabled', description: 'Build the test clients and register the test suite')

--- a/seat.c
+++ b/seat.c
@@ -12,8 +12,10 @@
 
 #include <assert.h>
 #include <linux/input-event-codes.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/multi.h>
@@ -23,6 +25,7 @@
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_keyboard_group.h>
+#include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_primary_selection.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_scene.h>
@@ -32,6 +35,7 @@
 #include <wlr/types/wlr_virtual_pointer_v1.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/util/log.h>
+#include <wlr/util/region.h>
 #if CAGE_HAS_XWAYLAND
 #include <wlr/xwayland.h>
 #endif
@@ -222,6 +226,18 @@ handle_new_pointer(struct cg_seat *seat, struct wlr_pointer *wlr_pointer)
 	wl_signal_add(&wlr_pointer->base.events.destroy, &pointer->destroy);
 
 	map_input_device_to_output(seat, &wlr_pointer->base, wlr_pointer->output_name);
+}
+
+static struct cg_pointer *
+pointer_from_wlr_pointer(struct cg_seat *seat, struct wlr_pointer *wlr_pointer)
+{
+	struct cg_pointer *pointer;
+	wl_list_for_each (pointer, &seat->pointers, link) {
+		if (pointer->pointer == wlr_pointer) {
+			return pointer;
+		}
+	}
+	return NULL;
 }
 
 static void
@@ -642,26 +658,534 @@ handle_cursor_button(struct wl_listener *listener, void *data)
 	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
-static void
-process_cursor_motion(struct cg_seat *seat, uint32_t time_msec, double dx, double dy, double dx_unaccel,
-		      double dy_unaccel)
-{
-	double sx, sy;
-	struct wlr_seat *wlr_seat = seat->seat;
-	struct wlr_surface *surface = NULL;
+/* Pointer constraints (zwp_pointer_constraints_v1): clients — games, or
+ * nested compositors on their behalf — ask for the pointer to be locked in
+ * place or confined to a region of their surface. The constraint of the
+ * pointer-focused surface is enforced: a locked pointer pins the cursor
+ * (clients follow the zwp_relative_pointer_v1 stream instead), a confined
+ * pointer is clamped to the constraint region. The active constraint always
+ * belongs to the pointer-focused surface — it is updated on every focus
+ * change — so the motion handlers below need not re-check the focus.
+ *
+ * A tracked constraint is not necessarily in effect. The protocol guarantees
+ * the pointer is inside the constraint region whenever the client is told the
+ * constraint activated, which an empty region cannot satisfy, so the
+ * constraint is only enforced while seat->constraint_enforced is set. */
 
-	struct cg_view *view = desktop_view_at(seat->server, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy);
-	if (!view) {
-		wlr_seat_pointer_clear_focus(wlr_seat);
-	} else {
-		wlr_seat_pointer_notify_enter(wlr_seat, surface, sx, sy);
-		wlr_seat_pointer_notify_motion(wlr_seat, time_msec, sx, sy);
+/* The scene node showing a surface, or NULL if it is not on screen. */
+static struct wlr_scene_node *
+scene_node_for_surface(struct wlr_scene_node *node, struct wlr_surface *surface)
+{
+	switch (node->type) {
+	case WLR_SCENE_NODE_BUFFER: {
+		struct wlr_scene_surface *scene_surface =
+			wlr_scene_surface_try_from_buffer(wlr_scene_buffer_from_node(node));
+		return scene_surface && scene_surface->surface == surface ? node : NULL;
+	}
+	case WLR_SCENE_NODE_TREE: {
+		struct wlr_scene_node *child;
+		wl_list_for_each (child, &wlr_scene_tree_from_node(node)->children, link) {
+			struct wlr_scene_node *found = scene_node_for_surface(child, surface);
+			if (found) {
+				return found;
+			}
+		}
+		return NULL;
+	}
+	default:
+		return NULL;
+	}
+}
+
+/* The cursor position in the coordinates of a constrained surface. Looked up
+ * in the scene graph rather than derived from the seat's surface-local
+ * position, which belongs to the focused surface — not necessarily this one —
+ * and rather than cached at activation, which goes stale as soon as the view
+ * is repositioned (an output is hotplugged, a mode change re-centers it). */
+static bool
+constraint_cursor_position(struct cg_seat *seat, struct wlr_pointer_constraint_v1 *constraint, double *sx, double *sy)
+{
+	struct wlr_scene_node *node = scene_node_for_surface(&seat->server->scene->tree.node, constraint->surface);
+	int lx, ly;
+	if (!node || !wlr_scene_node_coords(node, &lx, &ly)) {
+		return false;
+	}
+	*sx = seat->cursor->x - lx;
+	*sy = seat->cursor->y - ly;
+	return true;
+}
+
+/* On deactivation, warp the cursor to the client's cursor-position hint so it
+ * reappears where the client last drew its own cursor. The hint is in surface
+ * coordinates. */
+static void
+warp_to_constraint_cursor_hint(struct cg_seat *seat)
+{
+	struct wlr_pointer_constraint_v1 *constraint = seat->active_constraint;
+
+	/* Only a constraint that was in effect has a cursor to restore. */
+	if (!seat->constraint_enforced || !constraint->current.cursor_hint.enabled) {
+		return;
 	}
 
+	double cursor_sx, cursor_sy;
+	if (!constraint_cursor_position(seat, constraint, &cursor_sx, &cursor_sy)) {
+		return;
+	}
+	double sx = constraint->current.cursor_hint.x;
+	double sy = constraint->current.cursor_hint.y;
+	if (!wlr_cursor_warp(seat->cursor, NULL, seat->cursor->x + sx - cursor_sx, seat->cursor->y + sy - cursor_sy)) {
+		/* The hint maps outside the output layout: the cursor did not
+		 * move, so leave the surface-local position alone too. */
+		return;
+	}
+	if (seat->seat->pointer_state.focused_surface == constraint->surface) {
+		/* Fix up the seat's surface-local position without sending a motion event. */
+		wlr_seat_pointer_warp(seat->seat, sx, sy);
+	}
+}
+
+/* The region a constraint confines the pointer to: its own region intersected
+ * with the surface's input region. wlroots computes this into
+ * constraint->region, but only on a commit of the surface — and at creation
+ * only for a constraint created with a region — so a constraint created
+ * without one has an empty region there until its next commit. Recompute it
+ * the same way instead of relying on, or writing to, wlroots' copy: writing to
+ * it would break the change detection that emits the set_region signal. */
+static void
+constraint_effective_region(struct wlr_pointer_constraint_v1 *constraint, pixman_region32_t *region)
+{
+	if (pixman_region32_not_empty(&constraint->current.region)) {
+		pixman_region32_intersect(region, &constraint->surface->input_region, &constraint->current.region);
+	} else {
+		pixman_region32_copy(region, &constraint->surface->input_region);
+	}
+}
+
+/* The point of the region nearest to (sx, sy), half a pixel inside the
+ * region's integer extents so the result still passes a floored
+ * pixman_region32_contains_point() test. Returns false for an empty region. */
+static bool
+region_nearest_point(pixman_region32_t *region, double sx, double sy, double *nx, double *ny)
+{
+	int nboxes;
+	pixman_box32_t *boxes = pixman_region32_rectangles(region, &nboxes);
+	double best = INFINITY;
+	for (int i = 0; i < nboxes; i++) {
+		double x = fmax(boxes[i].x1 + 0.5, fmin(sx, boxes[i].x2 - 0.5));
+		double y = fmax(boxes[i].y1 + 0.5, fmin(sy, boxes[i].y2 - 0.5));
+		double distance = (x - sx) * (x - sx) + (y - sy) * (y - sy);
+		if (distance < best) {
+			best = distance;
+			*nx = x;
+			*ny = y;
+		}
+	}
+	return nboxes > 0;
+}
+
+/* Both a locked and a confined pointer must be inside the constraint region
+ * while the constraint is in effect; warp the cursor to the nearest point
+ * inside the region if it is outside. sx/sy are the cursor's surface-local
+ * coordinates and are updated on warp. Returns false if the cursor could not
+ * be placed inside the region — it is empty, or the point nearest to the
+ * cursor lies outside the output layout — in which case the cursor did not
+ * move. */
+static bool
+constraint_warp_into_region(struct cg_seat *seat, pixman_region32_t *region, double *sx, double *sy)
+{
+	if (pixman_region32_contains_point(region, (int) floor(*sx), (int) floor(*sy), NULL)) {
+		return true;
+	}
+
+	double nx = 0, ny = 0;
+	if (!region_nearest_point(region, *sx, *sy, &nx, &ny)) {
+		/* An empty region has no inside to warp to. */
+		return false;
+	}
+	if (!wlr_cursor_warp(seat->cursor, NULL, seat->cursor->x + nx - *sx, seat->cursor->y + ny - *sy)) {
+		return false;
+	}
+	*sx = nx;
+	*sy = ny;
+	return true;
+}
+
+/* Put the cursor inside the active constraint's effective region and keep the
+ * seat's surface-local position in sync with it. Returns false if the region
+ * cannot hold the cursor, in which case the constraint must not be enforced:
+ * a pointer outside the region cannot be confined by it, and every
+ * wlr_region_confine() from there would fail. */
+static bool
+constraint_enforce_region(struct cg_seat *seat, bool send_motion, uint32_t time_msec)
+{
+	struct wlr_pointer_constraint_v1 *constraint = seat->active_constraint;
+
+	double sx, sy;
+	if (!constraint_cursor_position(seat, constraint, &sx, &sy)) {
+		return false;
+	}
+
+	if (!constraint_warp_into_region(seat, &seat->constraint_region, &sx, &sy)) {
+		return false;
+	}
+	/* Compare against the seat's surface-local position, not the cursor's
+	 * layout position: when the surface moved under a stationary cursor,
+	 * no warp happens but sx/sy still changed, and a stale surface-local
+	 * position would misdirect every clamp in constrain_delta(). */
+	struct wlr_seat_pointer_state *pointer_state = &seat->seat->pointer_state;
+	if (pointer_state->focused_surface != constraint->surface ||
+	    (pointer_state->sx == sx && pointer_state->sy == sy)) {
+		return true;
+	}
+	if (send_motion) {
+		/* zwp_confined_pointer_v1.set_region: "If warped, a
+		 * wl_pointer.motion event will be emitted." Sending the motion
+		 * updates the seat's surface-local position too — warping that
+		 * silently first would make the motion look like a duplicate
+		 * and drop it, leaving the client uncorrected. */
+		wlr_seat_pointer_notify_motion(seat->seat, time_msec, sx, sy);
+	} else {
+		wlr_seat_pointer_warp(seat->seat, sx, sy);
+	}
+	return true;
+}
+
+static void
+handle_constraint_sync_idle(void *data)
+{
+	struct cg_seat *seat = data;
+	seat->constraint_sync_idle = NULL;
+
+	if (!seat->active_constraint || seat->constraint_enforced == seat->constraint_notified) {
+		return;
+	}
+	seat->constraint_notified = seat->constraint_enforced;
+	if (seat->constraint_notified) {
+		wlr_pointer_constraint_v1_send_activated(seat->active_constraint);
+	} else {
+		/* This destroys a oneshot constraint, which runs
+		 * handle_constraint_destroy() and detaches us. */
+		wlr_pointer_constraint_v1_send_deactivated(seat->active_constraint);
+	}
+}
+
+/* Tell the client whether its constraint is in effect, from an idle callback.
+ * Deactivating a oneshot constraint destroys it, and a region update that can
+ * cause that is emitted from inside the surface commit whose synced state
+ * wlroots is still iterating over — freeing the constraint there would pull an
+ * entry out from under that loop. The idle runs before the client is flushed,
+ * so it sees no delay, and a burst of region updates collapses into at most
+ * one event. */
+static void
+constraint_sync_client(struct cg_seat *seat)
+{
+	if (seat->constraint_sync_idle || seat->constraint_enforced == seat->constraint_notified) {
+		return;
+	}
+	struct wl_event_loop *loop = wl_display_get_event_loop(seat->server->wl_display);
+	seat->constraint_sync_idle = wl_event_loop_add_idle(loop, handle_constraint_sync_idle, seat);
+	if (!seat->constraint_sync_idle) {
+		wlr_log(WLR_ERROR, "Cannot notify a client of its pointer constraint's state");
+	}
+}
+
+/* Drop all of our state for the active constraint. An inactive constraint has
+ * none, so the listeners live in cg_seat rather than in a per-constraint
+ * allocation and are only linked while a constraint is active. */
+static void
+constraint_detach(struct cg_seat *seat)
+{
+	seat->active_constraint = NULL;
+	seat->constraint_enforced = false;
+	seat->constraint_notified = false;
+	pixman_region32_clear(&seat->constraint_region);
+	if (seat->constraint_sync_idle) {
+		wl_event_source_remove(seat->constraint_sync_idle);
+		seat->constraint_sync_idle = NULL;
+	}
+	wl_list_remove(&seat->constraint_set_region.link);
+	wl_list_init(&seat->constraint_set_region.link);
+	wl_list_remove(&seat->constraint_destroy.link);
+	wl_list_init(&seat->constraint_destroy.link);
+}
+
+/* Re-evaluate whether the active constraint can be enforced from the cursor's
+ * and the surface's current positions, and tell the client when the answer
+ * changes. send_motion asks for the wl_pointer.motion event that
+ * zwp_confined_pointer_v1.set_region mandates for a warp it causes. */
+static void
+constraint_update(struct cg_seat *seat, bool send_motion, uint32_t time_msec)
+{
+	struct wlr_pointer_constraint_v1 *constraint = seat->active_constraint;
+	if (!constraint) {
+		return;
+	}
+
+	if (seat->constraint_enforced && constraint->type == WLR_POINTER_CONSTRAINT_V1_LOCKED) {
+		/* The lock region only gates activation — the protocol calls it
+		 * "where the pointer must be in order for the lock to
+		 * activate" — so a pointer that is already locked stays pinned
+		 * whatever happens to the region. */
+		return;
+	}
+
+	send_motion = send_motion && seat->constraint_enforced;
+	seat->constraint_enforced = constraint_enforce_region(seat, send_motion, time_msec);
+	constraint_sync_client(seat);
+}
+
+static uint32_t
+now_msec(void)
+{
+	struct timespec now = {0};
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	return (uint32_t) (now.tv_sec * 1000 + now.tv_nsec / 1000000);
+}
+
+/* wlroots recomputed the constraint's effective region: a committed set_region
+ * request or a changed input region altered it. Re-validate the cursor
+ * position so a confined pointer cannot end up — and then be stuck — outside
+ * the new region. */
+static void
+handle_constraint_set_region(struct wl_listener *listener, void *data)
+{
+	struct cg_seat *seat = wl_container_of(listener, seat, constraint_set_region);
+
+	constraint_effective_region(seat->active_constraint, &seat->constraint_region);
+	constraint_update(seat, true, now_msec());
+}
+
+static void
+handle_constraint_destroy(struct wl_listener *listener, void *data)
+{
+	struct cg_seat *seat = wl_container_of(listener, seat, constraint_destroy);
+
+	/* The resource is going away: apply the hint, but send nothing. */
+	warp_to_constraint_cursor_hint(seat);
+	constraint_detach(seat);
+}
+
+static void
+constraint_set_active(struct cg_seat *seat, struct wlr_pointer_constraint_v1 *constraint)
+{
+	if (seat->active_constraint == constraint) {
+		return;
+	}
+
+	if (seat->active_constraint) {
+		struct wlr_pointer_constraint_v1 *prev = seat->active_constraint;
+		bool notified = seat->constraint_notified;
+		warp_to_constraint_cursor_hint(seat);
+		/* send_deactivated() destroys a oneshot constraint
+		 * synchronously; detach our state first so the destroy signal
+		 * finds no listener of ours left. */
+		constraint_detach(seat);
+		if (notified) {
+			wlr_pointer_constraint_v1_send_deactivated(prev);
+		}
+	}
+
+	if (!constraint) {
+		return;
+	}
+
+	seat->active_constraint = constraint;
+	seat->constraint_set_region.notify = handle_constraint_set_region;
+	wl_signal_add(&constraint->events.set_region, &seat->constraint_set_region);
+	seat->constraint_destroy.notify = handle_constraint_destroy;
+	wl_signal_add(&constraint->events.destroy, &seat->constraint_destroy);
+
+	constraint_effective_region(constraint, &seat->constraint_region);
+	constraint_update(seat, false, 0);
+}
+
+void
+handle_pointer_constraint(struct wl_listener *listener, void *data)
+{
+	struct cg_server *server = wl_container_of(listener, server, new_constraint);
+	struct wlr_pointer_constraint_v1 *constraint = data;
+	struct cg_seat *seat = server->seat;
+
+	if (seat->seat->pointer_state.focused_surface == constraint->surface) {
+		constraint_set_active(seat, constraint);
+	}
+}
+
+/* The views moved — an output was hotplugged, a mode or scale change
+ * re-centered them — and wlroots warped the cursor to keep it inside the
+ * layout. Both the constrained surface and the cursor may have moved, so the
+ * constraint has to be enforced again from their new positions: a confined
+ * pointer left outside its region would otherwise stay wedged there for as
+ * long as the constraint lives. */
+void
+seat_revalidate_pointer_constraint(struct cg_seat *seat)
+{
+	if (!seat || !seat->active_constraint) {
+		return;
+	}
+
+	constraint_effective_region(seat->active_constraint, &seat->constraint_region);
+	constraint_update(seat, true, now_msec());
+}
+
+static void
+handle_pointer_focus_change(struct wl_listener *listener, void *data)
+{
+	struct cg_seat *seat = wl_container_of(listener, seat, pointer_focus_change);
+	struct wlr_seat_pointer_focus_change_event *event = data;
+
+	/* Constraints follow pointer focus. */
+	struct wlr_pointer_constraint_v1 *constraint = NULL;
+	if (event->new_surface) {
+		constraint = wlr_pointer_constraints_v1_constraint_for_surface(seat->server->pointer_constraints,
+									       event->new_surface, seat->seat);
+	}
+	constraint_set_active(seat, constraint);
+}
+
+/* Whether the active constraint pins the cursor in place. */
+static bool
+constraint_locks_cursor(struct cg_seat *seat)
+{
+	return seat->constraint_enforced && seat->active_constraint->type == WLR_POINTER_CONSTRAINT_V1_LOCKED;
+}
+
+/* Clamp a cursor motion to what the active constraint allows. dx/dy are in
+ * layout coordinates, which have the same scale as the constrained surface's
+ * coordinates. */
+static void
+constrain_delta(struct cg_seat *seat, double *dx, double *dy)
+{
+	if (!seat->constraint_enforced) {
+		return;
+	}
+	if (constraint_locks_cursor(seat)) {
+		/* Locked: the cursor stays pinned; the client follows the
+		 * relative stream sent by process_cursor_motion(). */
+		*dx = *dy = 0;
+		return;
+	}
+
+	/* Confined: clamp the target to the constraint region, sliding along
+	 * its edges. The seat's surface-local position is the constrained
+	 * surface's — the active constraint always belongs to the focused
+	 * surface — and every warp of ours keeps it in sync with the cursor. */
+	struct wlr_seat_pointer_state *pointer_state = &seat->seat->pointer_state;
+	double sx = pointer_state->sx;
+	double sy = pointer_state->sy;
+	double sx_confined, sy_confined;
+	if (wlr_region_confine(&seat->constraint_region, sx, sy, sx + *dx, sy + *dy, &sx_confined, &sy_confined)) {
+		*dx = sx_confined - sx;
+		*dy = sy_confined - sy;
+		return;
+	}
+
+	/* wlr_region_confine() cannot clamp from a start point the region does
+	 * not contain, and the cursor can be left outside it after all: the
+	 * surface moved out from under it, or the region shrank away from it
+	 * between two of our checks. Head back to the nearest point inside
+	 * rather than freezing until the constraint dies. */
+	double nx = 0, ny = 0;
+	if (region_nearest_point(&seat->constraint_region, sx, sy, &nx, &ny)) {
+		*dx = nx - sx;
+		*dy = ny - sy;
+	} else {
+		*dx = *dy = 0;
+	}
+}
+
+/* Bring the pointer focus, and the client's view of the pointer, in line with
+ * the cursor. scene_changed tells apart the two ways this is reached: a cursor
+ * motion, or a change in what is on screen with the cursor standing still. */
+static void
+process_cursor_motion(struct cg_seat *seat, uint32_t time_msec, double dx, double dy, double dx_unaccel,
+		      double dy_unaccel, bool scene_changed)
+{
+	struct wlr_seat *wlr_seat = seat->seat;
+
+	/* Send the relative motion before any focus change below: a surface
+	 * that is entered — and whose constraint is activated — by this very
+	 * motion must not receive the traversal delta as its first event. */
 	if (dx != 0 || dy != 0) {
 		wlr_relative_pointer_manager_v1_send_relative_motion(seat->server->relative_pointer_manager, wlr_seat,
 								     (uint64_t) time_msec * 1000, dx, dy, dx_unaccel,
 								     dy_unaccel);
+	}
+
+	if (!scene_changed && constraint_locks_cursor(seat)) {
+		/* The cursor is pinned — constrain_delta() zeroed the motion —
+		 * so nothing under it changed, the focus cannot move, and a
+		 * locked pointer receives no wl_pointer.motion anyway. The
+		 * relative stream above is all the client gets. */
+		wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
+		return;
+	}
+
+	double sx, sy;
+	struct wlr_surface *surface = NULL;
+	struct cg_view *view = desktop_view_at(seat->server, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy);
+
+	/* Entering the surface activates its constraint (see
+	 * handle_pointer_focus_change()); warp the pointer into the constraint
+	 * region first, so the client is never told of an out-of-region
+	 * position — a lock in particular guarantees the pointer is inside the
+	 * region when it activates. The warp moves the cursor, so look up what
+	 * is topmost again: the constrained surface may well be occluded at the
+	 * position we warped to. */
+	if (view && surface != wlr_seat->pointer_state.focused_surface) {
+		struct wlr_pointer_constraint_v1 *next = wlr_pointer_constraints_v1_constraint_for_surface(
+			seat->server->pointer_constraints, surface, wlr_seat);
+		if (next) {
+			pixman_region32_t region;
+			pixman_region32_init(&region);
+			constraint_effective_region(next, &region);
+			double cursor_x = seat->cursor->x;
+			double cursor_y = seat->cursor->y;
+			constraint_warp_into_region(seat, &region, &sx, &sy);
+			pixman_region32_fini(&region);
+			if (seat->cursor->x != cursor_x || seat->cursor->y != cursor_y) {
+				view = desktop_view_at(seat->server, seat->cursor->x, seat->cursor->y, &surface, &sx,
+						       &sy);
+			}
+		}
+	}
+
+	if (!view) {
+		wlr_seat_pointer_clear_focus(wlr_seat);
+	} else if (surface != wlr_seat->pointer_state.focused_surface) {
+		double pre_enter_x = seat->cursor->x;
+		double pre_enter_y = seat->cursor->y;
+		wlr_seat_pointer_notify_enter(wlr_seat, surface, sx, sy);
+		if (seat->cursor->x != pre_enter_x || seat->cursor->y != pre_enter_y) {
+			/* Entering the surface deactivated the previous
+			 * constraint, whose cursor-position hint warped the
+			 * cursor; rebase on the warped position so the motion
+			 * below does not undo the warp. */
+			view = desktop_view_at(seat->server, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy);
+			if (!view) {
+				wlr_seat_pointer_clear_focus(wlr_seat);
+			} else if (surface != wlr_seat->pointer_state.focused_surface) {
+				wlr_seat_pointer_notify_enter(wlr_seat, surface, sx, sy);
+			}
+		}
+	}
+	if (view) {
+		/* A locked pointer receives no motion events at all — not even
+		 * if the surface moved under the pinned cursor and sx/sy
+		 * changed. Read the constraint after the enter: entering the
+		 * surface may have just activated it. */
+		if (constraint_locks_cursor(seat)) {
+			/* Keep the seat's surface-local position in sync all the
+			 * same. An enter for the already-focused surface is a
+			 * no-op in wlroots, so a warp between the two enters
+			 * above would leave it at the pre-warp coordinates — and
+			 * every later motion would be deduplicated against
+			 * them. */
+			wlr_seat_pointer_warp(wlr_seat, sx, sy);
+		} else {
+			wlr_seat_pointer_notify_motion(wlr_seat, time_msec, sx, sy);
+		}
 	}
 
 	struct cg_drag_icon *drag_icon;
@@ -681,11 +1205,48 @@ handle_cursor_motion_absolute(struct wl_listener *listener, void *data)
 	double lx, ly;
 	wlr_cursor_absolute_to_layout_coords(seat->cursor, &event->pointer->base, event->x, event->y, &lx, &ly);
 
-	double dx = lx - seat->cursor->x;
-	double dy = ly - seat->cursor->y;
+	/* The synthesized relative motion is the distance the device travelled,
+	 * which is only the distance to the cursor as long as the cursor is
+	 * free to follow it: a constraint can hold the cursor back. Difference
+	 * against this device's own previous absolute position instead, and
+	 * fall back to the cursor until it has one. */
+	struct cg_pointer *pointer = pointer_from_wlr_pointer(seat, event->pointer);
+	double dx, dy;
+	if (pointer && pointer->last_abs_valid) {
+		dx = lx - pointer->last_abs_x;
+		dy = ly - pointer->last_abs_y;
+	} else if (!seat->constraint_enforced) {
+		dx = lx - seat->cursor->x;
+		dy = ly - seat->cursor->y;
+	} else {
+		/* Nothing meaningful to synthesize: the device has no history,
+		 * and the cursor is not where the device is. */
+		dx = dy = 0;
+	}
+	if (pointer) {
+		pointer->last_abs_x = lx;
+		pointer->last_abs_y = ly;
+		pointer->last_abs_valid = true;
+	}
 
-	wlr_cursor_warp_absolute(seat->cursor, &event->pointer->base, event->x, event->y);
-	process_cursor_motion(seat, event->time_msec, dx, dy, dx, dy);
+	if (seat->constraint_enforced) {
+		/* Turn the absolute target into a motion the constraint can
+		 * clamp, then warp to the closest point the layout and the
+		 * device's output mapping allow: a target inside the constraint
+		 * region can still fall outside those, and dropping the event
+		 * instead would wedge the pointer. */
+		double move_x = lx - seat->cursor->x;
+		double move_y = ly - seat->cursor->y;
+		constrain_delta(seat, &move_x, &move_y);
+		if (move_x != 0 || move_y != 0) {
+			wlr_cursor_warp_closest(seat->cursor, &event->pointer->base, seat->cursor->x + move_x,
+						seat->cursor->y + move_y);
+		}
+	} else {
+		wlr_cursor_warp_absolute(seat->cursor, &event->pointer->base, event->x, event->y);
+	}
+
+	process_cursor_motion(seat, event->time_msec, dx, dy, dx, dy, false);
 	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
@@ -695,9 +1256,17 @@ handle_cursor_motion_relative(struct wl_listener *listener, void *data)
 	struct cg_seat *seat = wl_container_of(listener, seat, cursor_motion_relative);
 	struct wlr_pointer_motion_event *event = data;
 
-	wlr_cursor_move(seat->cursor, &event->pointer->base, event->delta_x, event->delta_y);
+	/* Constrain the motion the cursor makes, but pass the raw deltas on to
+	 * process_cursor_motion() so the relative stream stays unclamped. */
+	double dx = event->delta_x;
+	double dy = event->delta_y;
+	constrain_delta(seat, &dx, &dy);
+	if (dx != 0 || dy != 0) {
+		wlr_cursor_move(seat->cursor, &event->pointer->base, dx, dy);
+	}
+
 	process_cursor_motion(seat, event->time_msec, event->delta_x, event->delta_y, event->unaccel_dx,
-			      event->unaccel_dy);
+			      event->unaccel_dy, false);
 	wlr_idle_notifier_v1_notify_activity(seat->server->idle, seat->seat);
 }
 
@@ -802,6 +1371,16 @@ handle_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&seat->cursor_button.link);
 	wl_list_remove(&seat->cursor_axis.link);
 	wl_list_remove(&seat->cursor_frame.link);
+	wl_list_remove(&seat->pointer_focus_change.link);
+	/* wlroots destroys any surviving constraint after us (its seat destroy
+	 * listeners were added later); unlink so its destroy signal does not
+	 * run our handler on the freed seat. */
+	wl_list_remove(&seat->constraint_set_region.link);
+	wl_list_remove(&seat->constraint_destroy.link);
+	if (seat->constraint_sync_idle) {
+		wl_event_source_remove(seat->constraint_sync_idle);
+	}
+	pixman_region32_fini(&seat->constraint_region);
 	wl_list_remove(&seat->touch_down.link);
 	wl_list_remove(&seat->touch_up.link);
 	wl_list_remove(&seat->touch_motion.link);
@@ -869,6 +1448,14 @@ seat_create(struct cg_server *server, struct wlr_backend *backend)
 	wl_signal_add(&seat->cursor->events.axis, &seat->cursor_axis);
 	seat->cursor_frame.notify = handle_cursor_frame;
 	wl_signal_add(&seat->cursor->events.frame, &seat->cursor_frame);
+
+	seat->pointer_focus_change.notify = handle_pointer_focus_change;
+	wl_signal_add(&seat->seat->pointer_state.events.focus_change, &seat->pointer_focus_change);
+	/* Only linked while a constraint is active; keep them initialized so
+	 * removal is always safe. */
+	wl_list_init(&seat->constraint_set_region.link);
+	wl_list_init(&seat->constraint_destroy.link);
+	pixman_region32_init(&seat->constraint_region);
 
 	seat->touch_down.notify = handle_touch_down;
 	wl_signal_add(&seat->cursor->events.touch_down, &seat->touch_down);
@@ -983,7 +1570,9 @@ seat_set_focus(struct cg_seat *seat, struct cg_view *view)
 		wlr_seat_keyboard_notify_enter(wlr_seat, view->wlr_surface, NULL, 0, NULL);
 	}
 
-	process_cursor_motion(seat, -1, 0, 0, 0, 0);
+	/* The newly focused view was raised over the cursor: re-resolve what the
+	 * cursor is over, even while a lock pins it in place. */
+	process_cursor_motion(seat, -1, 0, 0, 0, 0, true);
 }
 
 void

--- a/seat.h
+++ b/seat.h
@@ -1,6 +1,7 @@
 #ifndef CG_SEAT_H
 #define CG_SEAT_H
 
+#include <pixman.h>
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_data_device.h>
@@ -30,6 +31,24 @@ struct cg_seat {
 	struct wl_listener cursor_button;
 	struct wl_listener cursor_axis;
 	struct wl_listener cursor_frame;
+
+	/* The constraint of the pointer-focused surface, if it has one. It is
+	 * only enforced — and only reported to the client as active — while its
+	 * effective region can hold the cursor. */
+	struct wlr_pointer_constraint_v1 *active_constraint;
+	/* The effective region of the active constraint (its region intersected
+	 * with the surface's input region), in surface coordinates. Ours to
+	 * compute: constraint->region is wlroots' own state. */
+	pixman_region32_t constraint_region;
+	bool constraint_enforced;
+	/* Whether the client has been sent an activated event that no
+	 * deactivated event has followed yet. It trails constraint_enforced
+	 * until constraint_sync_idle runs. */
+	bool constraint_notified;
+	struct wl_event_source *constraint_sync_idle;
+	struct wl_listener constraint_set_region;
+	struct wl_listener constraint_destroy;
+	struct wl_listener pointer_focus_change;
 
 	int32_t touch_id;
 	double touch_lx;
@@ -62,6 +81,15 @@ struct cg_pointer {
 	struct cg_seat *seat;
 	struct wlr_pointer *pointer;
 
+	/* Reference for synthesizing relative motion from this device's
+	 * absolute events: a constraint can keep the cursor from following the
+	 * device, so consecutive absolute positions must be differenced
+	 * directly instead of against the cursor. The reference is per device:
+	 * differencing positions of two different absolute devices would turn
+	 * their distance into a spurious delta. */
+	double last_abs_x, last_abs_y;
+	bool last_abs_valid;
+
 	struct wl_listener destroy;
 };
 
@@ -90,6 +118,8 @@ void seat_destroy(struct cg_seat *seat);
 struct cg_view *seat_get_focus(struct cg_seat *seat);
 void seat_set_focus(struct cg_seat *seat, struct cg_view *view);
 void seat_center_cursor(struct cg_seat *seat);
+void seat_revalidate_pointer_constraint(struct cg_seat *seat);
 
 void handle_request_set_shape(struct wl_listener *listener, void *data);
+void handle_pointer_constraint(struct wl_listener *listener, void *data);
 #endif

--- a/server.h
+++ b/server.h
@@ -9,6 +9,7 @@
 #include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_xdg_decoration_v1.h>
 #include <wlr/util/log.h>
@@ -67,6 +68,9 @@ struct cg_server {
 #endif
 
 	struct wlr_relative_pointer_manager_v1 *relative_pointer_manager;
+
+	struct wlr_pointer_constraints_v1 *pointer_constraints;
+	struct wl_listener new_constraint;
 
 	struct wlr_foreign_toplevel_manager_v1 *foreign_toplevel_manager;
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,39 @@
+wl_protocol_dir = wayland_protos.get_variable(pkgconfig: 'pkgdatadir')
+
+test_protocols = [
+  wl_protocol_dir / 'stable/xdg-shell/xdg-shell.xml',
+  wl_protocol_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml',
+  wl_protocol_dir / 'unstable/relative-pointer/relative-pointer-unstable-v1.xml',
+  # Not part of wayland-protocols; vendored from wlr-protocols.
+  'wlr-virtual-pointer-unstable-v1.xml',
+  'wlr-output-management-unstable-v1.xml',
+]
+
+test_protocol_src = []
+foreach xml : test_protocols
+  test_protocol_src += custom_target(
+    fs.stem(xml) + '-code',
+    input: xml,
+    output: '@BASENAME@-protocol.c',
+    command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+  )
+  test_protocol_src += custom_target(
+    fs.stem(xml) + '-client-header',
+    input: xml,
+    output: '@BASENAME@-client-protocol.h',
+    command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+  )
+endforeach
+
+pointer_constraints_client = executable(
+  'pointer-constraints-client',
+  ['pointer-constraints.c'] + test_protocol_src,
+  dependencies: [wayland_client, math],
+)
+
+test(
+  'pointer-constraints',
+  find_program('run-test.sh'),
+  args: [cage, pointer_constraints_client],
+  timeout: 90,
+)

--- a/tests/pointer-constraints.c
+++ b/tests/pointer-constraints.c
@@ -1,0 +1,927 @@
+/*
+ * Cage: A Wayland kiosk.
+ *
+ * Functional test for pointer-constraint enforcement.
+ *
+ * Runs as cage's application on the headless backend (see run-test.sh) and
+ * drives the compositor from the inside: a zwlr_virtual_pointer_v1 injects
+ * input, while a fullscreen toplevel locks its pointer and observes what
+ * comes back. Asserts that:
+ *
+ *   1. the lock activates when the surface gains pointer focus,
+ *   2. absolute motion is not delivered as wl_pointer.motion while locked
+ *      (the cursor stays pinned), but relative deltas keep flowing,
+ *   3. real relative motion reaches the client unmodified while locked,
+ *   4. destroying the lock applies the cursor-position hint: a subsequent
+ *      relative move lands at hint + delta,
+ *   5. shrinking a confined pointer's region below the cursor position warps
+ *      the cursor into the new region — reporting the warp as a
+ *      wl_pointer.motion, as set_region mandates — instead of wedging the
+ *      pointer, and absolute motion aimed outside the region is clamped to its
+ *      edge,
+ *   6. a confinement whose effective region becomes empty (the constraint
+ *      region no longer intersects the input region) is deactivated and lets
+ *      the pointer move, and is activated again once the region can hold the
+ *      pointer,
+ *   7. locking while the cursor is outside the lock's region warps the
+ *      pointer into the region, as the protocol guarantees on activation,
+ *      while a region committed after the lock activated leaves the pinned
+ *      pointer alone,
+ *   8. a oneshot lock is deactivated when the pointer focus moves to another
+ *      toplevel — applying its cursor-position hint even though the focus is
+ *      already elsewhere — and the compositor survives the deactivation
+ *      (wlroots destroys a oneshot constraint from inside send_deactivated()),
+ *   9. when a centered view moves under a stationary cursor — an output mode
+ *      change, applied through zwlr_output_manager_v1, re-centers it — the
+ *      seat's surface-local position is resynced and reported as a
+ *      wl_pointer.motion, and later confinement clamps run from the new
+ *      position rather than the stale one (from which the pointer could
+ *      escape the region).
+ *
+ * Exits 0 on success; cage propagates the exit code when its child exits.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <math.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
+#include <wayland-client.h>
+
+#include "pointer-constraints-unstable-v1-client-protocol.h"
+#include "relative-pointer-unstable-v1-client-protocol.h"
+#include "wlr-output-management-unstable-v1-client-protocol.h"
+#include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
+#include "xdg-shell-client-protocol.h"
+
+#define check(cond, ...)                                                                                               \
+	do {                                                                                                           \
+		if (!(cond)) {                                                                                         \
+			fprintf(stderr, "FAIL(%d): ", __LINE__);                                                       \
+			fprintf(stderr, __VA_ARGS__);                                                                  \
+			fprintf(stderr, "\n");                                                                         \
+			exit(1);                                                                                       \
+		}                                                                                                      \
+	} while (0)
+
+static struct wl_display *display;
+static struct wl_compositor *compositor;
+static struct wl_shm *shm;
+static struct wl_seat *seat;
+static struct xdg_wm_base *wm_base;
+static struct zwp_pointer_constraints_v1 *constraints;
+static struct zwp_relative_pointer_manager_v1 *relative_manager;
+static struct zwlr_virtual_pointer_manager_v1 *virtual_pointer_manager;
+static struct zwlr_output_manager_v1 *output_manager;
+
+static struct wl_surface *surface;
+static struct zwlr_virtual_pointer_v1 *virtual_pointer;
+static struct wl_pointer *pointer;
+static struct zwp_locked_pointer_v1 *locked_pointer;
+static struct zwp_confined_pointer_v1 *confined_pointer;
+
+static bool mapped;
+static bool locked;
+static bool confined;
+static bool have_enter;
+static double enter_sx, enter_sy;
+static bool have_motion;
+static double motion_sx, motion_sy;
+static int motion_events;
+static int leave_events;
+static int rel_events;
+static bool have_rel_12_7;
+
+static struct zwlr_output_head_v1 *output_head;
+static uint32_t output_manager_serial;
+static bool output_manager_done;
+static int output_config_result; /* 0 pending, 1 succeeded, -1 failed or cancelled */
+
+/* The head's per-output events (name, modes, ...) are of no use here — only
+ * the head object itself is, to enable it with a custom mode — so no listener
+ * is attached to it. */
+static void
+output_manager_handle_head(void *data, struct zwlr_output_manager_v1 *manager, struct zwlr_output_head_v1 *head)
+{
+	check(output_head == NULL, "expected a single output head");
+	output_head = head;
+}
+
+static void
+output_manager_handle_done(void *data, struct zwlr_output_manager_v1 *manager, uint32_t serial)
+{
+	output_manager_serial = serial;
+	output_manager_done = true;
+}
+
+static void
+output_manager_handle_finished(void *data, struct zwlr_output_manager_v1 *manager)
+{
+}
+
+static const struct zwlr_output_manager_v1_listener output_manager_listener = {
+	.head = output_manager_handle_head,
+	.done = output_manager_handle_done,
+	.finished = output_manager_handle_finished,
+};
+
+static void
+output_config_succeeded(void *data, struct zwlr_output_configuration_v1 *config)
+{
+	output_config_result = 1;
+}
+
+static void
+output_config_failed(void *data, struct zwlr_output_configuration_v1 *config)
+{
+	output_config_result = -1;
+}
+
+static void
+output_config_cancelled(void *data, struct zwlr_output_configuration_v1 *config)
+{
+	output_config_result = -1;
+}
+
+static const struct zwlr_output_configuration_v1_listener output_config_listener = {
+	.succeeded = output_config_succeeded,
+	.failed = output_config_failed,
+	.cancelled = output_config_cancelled,
+};
+
+// ---- registry ----
+
+static void
+registry_global(void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version)
+{
+	if (strcmp(interface, wl_compositor_interface.name) == 0) {
+		compositor = wl_registry_bind(registry, name, &wl_compositor_interface, 4);
+	} else if (strcmp(interface, wl_shm_interface.name) == 0) {
+		shm = wl_registry_bind(registry, name, &wl_shm_interface, 1);
+	} else if (strcmp(interface, wl_seat_interface.name) == 0) {
+		seat = wl_registry_bind(registry, name, &wl_seat_interface, version < 5 ? version : 5);
+	} else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+		wm_base = wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
+	} else if (strcmp(interface, zwp_pointer_constraints_v1_interface.name) == 0) {
+		constraints = wl_registry_bind(registry, name, &zwp_pointer_constraints_v1_interface, 1);
+	} else if (strcmp(interface, zwp_relative_pointer_manager_v1_interface.name) == 0) {
+		relative_manager = wl_registry_bind(registry, name, &zwp_relative_pointer_manager_v1_interface, 1);
+	} else if (strcmp(interface, zwlr_virtual_pointer_manager_v1_interface.name) == 0) {
+		virtual_pointer_manager =
+			wl_registry_bind(registry, name, &zwlr_virtual_pointer_manager_v1_interface, 1);
+	} else if (strcmp(interface, zwlr_output_manager_v1_interface.name) == 0) {
+		output_manager = wl_registry_bind(registry, name, &zwlr_output_manager_v1_interface, 1);
+		zwlr_output_manager_v1_add_listener(output_manager, &output_manager_listener, NULL);
+	}
+}
+
+static void
+registry_global_remove(void *data, struct wl_registry *registry, uint32_t name)
+{
+}
+
+static const struct wl_registry_listener registry_listener = {
+	.global = registry_global,
+	.global_remove = registry_global_remove,
+};
+
+// ---- xdg-shell ----
+
+static void
+wm_base_ping(void *data, struct xdg_wm_base *base, uint32_t serial)
+{
+	xdg_wm_base_pong(base, serial);
+}
+
+static const struct xdg_wm_base_listener wm_base_listener = {
+	.ping = wm_base_ping,
+};
+
+static int32_t configured_width, configured_height;
+
+static void
+toplevel_configure(void *data, struct xdg_toplevel *toplevel, int32_t w, int32_t h, struct wl_array *states)
+{
+	configured_width = w;
+	configured_height = h;
+}
+
+static void
+toplevel_close(void *data, struct xdg_toplevel *toplevel)
+{
+	check(false, "toplevel closed by the compositor");
+}
+
+static const struct xdg_toplevel_listener toplevel_listener = {
+	.configure = toplevel_configure,
+	.close = toplevel_close,
+};
+
+static struct wl_buffer *
+make_buffer(int32_t width, int32_t height)
+{
+	char template[] = "/tmp/cage-test-shm-XXXXXX";
+	int stride = width * 4;
+	int size = stride * height;
+	int fd = mkstemp(template);
+	check(fd >= 0, "cannot create shm file");
+	unlink(template);
+	check(ftruncate(fd, size) == 0, "cannot truncate shm file");
+
+	void *pixels = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	check(pixels != MAP_FAILED, "cannot map shm buffer");
+	memset(pixels, 0x77, size);
+	munmap(pixels, size);
+
+	struct wl_shm_pool *pool = wl_shm_create_pool(shm, fd, size);
+	struct wl_buffer *buffer = wl_shm_pool_create_buffer(pool, 0, width, height, stride, WL_SHM_FORMAT_XRGB8888);
+	wl_shm_pool_destroy(pool);
+	close(fd);
+	return buffer;
+}
+
+static void
+xdg_surface_handle_configure(void *data, struct xdg_surface *xdg_surface, uint32_t serial)
+{
+	xdg_surface_ack_configure(xdg_surface, serial);
+	if (!mapped) {
+		mapped = true;
+		/* Commit at the configured size, so the (maximized) surface
+		 * covers the whole output and the cursor is always over it. */
+		int32_t width = configured_width > 0 ? configured_width : 640;
+		int32_t height = configured_height > 0 ? configured_height : 480;
+		wl_surface_attach(surface, make_buffer(width, height), 0, 0);
+		wl_surface_commit(surface);
+	}
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+	.configure = xdg_surface_handle_configure,
+};
+
+/* Second toplevel, mapped later to take the pointer focus away. */
+static struct wl_surface *surface2;
+static bool mapped2;
+
+static void
+xdg_surface2_handle_configure(void *data, struct xdg_surface *xdg_surface, uint32_t serial)
+{
+	xdg_surface_ack_configure(xdg_surface, serial);
+	if (!mapped2) {
+		mapped2 = true;
+		int32_t width = configured_width > 0 ? configured_width : 640;
+		int32_t height = configured_height > 0 ? configured_height : 480;
+		wl_surface_attach(surface2, make_buffer(width, height), 0, 0);
+		wl_surface_commit(surface2);
+	}
+}
+
+static const struct xdg_surface_listener xdg_surface2_listener = {
+	.configure = xdg_surface2_handle_configure,
+};
+
+/* Third toplevel: a small dialog with an xdg_toplevel parent, so cage centers
+ * it instead of maximizing it — the view that moves when the output shrinks. */
+#define DIALOG_SIZE 200
+
+static struct wl_surface *surface3;
+static bool mapped3;
+
+static void
+xdg_surface3_handle_configure(void *data, struct xdg_surface *xdg_surface, uint32_t serial)
+{
+	xdg_surface_ack_configure(xdg_surface, serial);
+	if (!mapped3) {
+		mapped3 = true;
+		wl_surface_attach(surface3, make_buffer(DIALOG_SIZE, DIALOG_SIZE), 0, 0);
+		wl_surface_commit(surface3);
+	}
+}
+
+static const struct xdg_surface_listener xdg_surface3_listener = {
+	.configure = xdg_surface3_handle_configure,
+};
+
+// ---- pointer + constraint events ----
+
+static void
+locked_handle_locked(void *data, struct zwp_locked_pointer_v1 *lp)
+{
+	locked = true;
+}
+
+static void
+locked_handle_unlocked(void *data, struct zwp_locked_pointer_v1 *lp)
+{
+	locked = false;
+}
+
+static const struct zwp_locked_pointer_v1_listener locked_listener = {
+	.locked = locked_handle_locked,
+	.unlocked = locked_handle_unlocked,
+};
+
+static void
+confined_handle_confined(void *data, struct zwp_confined_pointer_v1 *cp)
+{
+	confined = true;
+}
+
+static void
+confined_handle_unconfined(void *data, struct zwp_confined_pointer_v1 *cp)
+{
+	confined = false;
+}
+
+static const struct zwp_confined_pointer_v1_listener confined_listener = {
+	.confined = confined_handle_confined,
+	.unconfined = confined_handle_unconfined,
+};
+
+static void
+pointer_enter(void *data, struct wl_pointer *p, uint32_t serial, struct wl_surface *s, wl_fixed_t sx, wl_fixed_t sy)
+{
+	have_enter = true;
+	enter_sx = wl_fixed_to_double(sx);
+	enter_sy = wl_fixed_to_double(sy);
+}
+
+static void
+pointer_leave(void *data, struct wl_pointer *p, uint32_t serial, struct wl_surface *s)
+{
+	leave_events++;
+}
+
+static void
+pointer_motion(void *data, struct wl_pointer *p, uint32_t time, wl_fixed_t sx, wl_fixed_t sy)
+{
+	have_motion = true;
+	motion_sx = wl_fixed_to_double(sx);
+	motion_sy = wl_fixed_to_double(sy);
+	motion_events++;
+}
+
+static void
+pointer_button(void *data, struct wl_pointer *p, uint32_t serial, uint32_t time, uint32_t button, uint32_t state)
+{
+}
+
+static void
+pointer_axis(void *data, struct wl_pointer *p, uint32_t time, uint32_t axis, wl_fixed_t value)
+{
+}
+
+static void
+pointer_frame(void *data, struct wl_pointer *p)
+{
+}
+
+static void
+pointer_axis_source(void *data, struct wl_pointer *p, uint32_t source)
+{
+}
+
+static void
+pointer_axis_stop(void *data, struct wl_pointer *p, uint32_t time, uint32_t axis)
+{
+}
+
+static void
+pointer_axis_discrete(void *data, struct wl_pointer *p, uint32_t axis, int32_t discrete)
+{
+}
+
+static const struct wl_pointer_listener pointer_listener = {
+	.enter = pointer_enter,
+	.leave = pointer_leave,
+	.motion = pointer_motion,
+	.button = pointer_button,
+	.axis = pointer_axis,
+	.frame = pointer_frame,
+	.axis_source = pointer_axis_source,
+	.axis_stop = pointer_axis_stop,
+	.axis_discrete = pointer_axis_discrete,
+};
+
+static void
+relative_motion(void *data, struct zwp_relative_pointer_v1 *rp, uint32_t hi, uint32_t lo, wl_fixed_t dx, wl_fixed_t dy,
+		wl_fixed_t udx, wl_fixed_t udy)
+{
+	rel_events++;
+	if (fabs(wl_fixed_to_double(dx) - 12.0) < 0.51 && fabs(wl_fixed_to_double(dy) - 7.0) < 0.51) {
+		have_rel_12_7 = true;
+	}
+}
+
+static const struct zwp_relative_pointer_v1_listener relative_listener = {
+	.relative_motion = relative_motion,
+};
+
+static void
+seat_capabilities(void *data, struct wl_seat *s, uint32_t capabilities)
+{
+	if ((capabilities & WL_SEAT_CAPABILITY_POINTER) && !pointer) {
+		pointer = wl_seat_get_pointer(seat);
+		wl_pointer_add_listener(pointer, &pointer_listener, NULL);
+
+		struct zwp_relative_pointer_v1 *relative =
+			zwp_relative_pointer_manager_v1_get_relative_pointer(relative_manager, pointer);
+		zwp_relative_pointer_v1_add_listener(relative, &relative_listener, NULL);
+
+		/* Lock before the surface has pointer focus: activation must
+		 * follow from the focus change. */
+		locked_pointer = zwp_pointer_constraints_v1_lock_pointer(
+			constraints, surface, pointer, NULL, ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+		zwp_locked_pointer_v1_add_listener(locked_pointer, &locked_listener, NULL);
+	}
+}
+
+static void
+seat_name(void *data, struct wl_seat *s, const char *name)
+{
+}
+
+static const struct wl_seat_listener seat_listener = {
+	.capabilities = seat_capabilities,
+	.name = seat_name,
+};
+
+// ---- test driver ----
+
+static int64_t
+now_ms(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+/* Dispatch events for up to timeout_ms, or until an event batch arrives. */
+static void
+pump(int timeout_ms)
+{
+	wl_display_flush(display);
+	struct pollfd pfd = {.fd = wl_display_get_fd(display), .events = POLLIN};
+	if (poll(&pfd, 1, timeout_ms) > 0) {
+		check(wl_display_dispatch(display) != -1, "display connection lost");
+	} else {
+		wl_display_dispatch_pending(display);
+	}
+}
+
+static void
+inject_absolute(uint32_t x, uint32_t y)
+{
+	zwlr_virtual_pointer_v1_motion_absolute(virtual_pointer, 0, x, y, 10000, 10000);
+	zwlr_virtual_pointer_v1_frame(virtual_pointer);
+}
+
+static void
+inject_relative(double dx, double dy)
+{
+	zwlr_virtual_pointer_v1_motion(virtual_pointer, 0, wl_fixed_from_double(dx), wl_fixed_from_double(dy));
+	zwlr_virtual_pointer_v1_frame(virtual_pointer);
+}
+
+int
+main(void)
+{
+	/* Backstop: die loudly rather than hang the test runner (a roundtrip
+	 * against a deadlocked compositor blocks forever). Only failing steps
+	 * wait their deadlines out — a passing run takes milliseconds — so
+	 * this must merely exceed the ~55s worst-case sum of the deadlines
+	 * below, and stay under the 90s meson timeout. */
+	alarm(70);
+
+	display = wl_display_connect(NULL);
+	check(display != NULL, "no wayland display");
+	struct wl_registry *registry = wl_display_get_registry(display);
+	wl_registry_add_listener(registry, &registry_listener, NULL);
+	wl_display_roundtrip(display);
+	check(compositor && shm && seat && wm_base, "missing core globals");
+	check(constraints != NULL, "zwp_pointer_constraints_v1 not advertised");
+	check(relative_manager != NULL, "zwp_relative_pointer_manager_v1 not advertised");
+	check(virtual_pointer_manager != NULL, "zwlr_virtual_pointer_manager_v1 not advertised");
+	check(output_manager != NULL, "zwlr_output_manager_v1 not advertised");
+
+	xdg_wm_base_add_listener(wm_base, &wm_base_listener, NULL);
+	wl_seat_add_listener(seat, &seat_listener, NULL);
+
+	/* The virtual pointer gives the seat its pointer capability; the
+	 * capability event then creates the wl_pointer and the lock. */
+	virtual_pointer = zwlr_virtual_pointer_manager_v1_create_virtual_pointer(virtual_pointer_manager, NULL);
+
+	surface = wl_compositor_create_surface(compositor);
+	struct xdg_surface *xdg_surface = xdg_wm_base_get_xdg_surface(wm_base, surface);
+	xdg_surface_add_listener(xdg_surface, &xdg_surface_listener, NULL);
+	struct xdg_toplevel *toplevel = xdg_surface_get_toplevel(xdg_surface);
+	xdg_toplevel_add_listener(toplevel, &toplevel_listener, NULL);
+	xdg_toplevel_set_title(toplevel, "pointer-constraints-test");
+	wl_surface_commit(surface);
+
+	/* 1. Move the pointer onto the surface: the lock must activate. The
+	 * injection is repeated (with jitter, so every send is a real motion
+	 * event) because it races the surface appearing on the compositor
+	 * side. */
+	int64_t deadline = now_ms() + 10000;
+	uint32_t jitter = 0;
+	while (!(mapped && locked_pointer && locked) && now_ms() < deadline) {
+		if (mapped && locked_pointer) {
+			inject_absolute(5000 + (jitter++ % 2) * 100, 5000);
+		}
+		pump(100);
+	}
+	check(locked, "pointer lock did not activate on focus");
+
+	/* 2. Absolute motion while locked: the cursor stays pinned (no
+	 * wl_pointer.motion or leave), but relative deltas are synthesized. */
+	motion_events = 0;
+	leave_events = 0;
+	rel_events = 0;
+	inject_absolute(2000, 2000);
+	inject_absolute(8000, 8000);
+	inject_absolute(3000, 7000);
+	/* 3. Real relative motion flows while locked, unmodified. */
+	inject_relative(12.0, 7.0);
+	wl_display_roundtrip(display);
+	deadline = now_ms() + 2000;
+	while ((rel_events < 4 || !have_rel_12_7) && now_ms() < deadline) {
+		pump(100);
+	}
+	check(motion_events == 0, "absolute motion leaked through the lock (%d motion events)", motion_events);
+	check(leave_events == 0, "pointer left the surface while locked");
+	check(rel_events >= 4, "expected relative deltas while locked, got %d", rel_events);
+	check(have_rel_12_7, "relative delta was modified by the lock");
+
+	/* 4. Destroy the lock with a cursor-position hint: the cursor must
+	 * reappear at the hint, so a relative move of (25, 30) from the hint
+	 * (100, 50) lands at exactly (125, 80). */
+	zwp_locked_pointer_v1_set_cursor_position_hint(locked_pointer, wl_fixed_from_int(100), wl_fixed_from_int(50));
+	wl_surface_commit(surface);
+	zwp_locked_pointer_v1_destroy(locked_pointer);
+	wl_display_roundtrip(display);
+
+	have_motion = false;
+	inject_relative(25.0, 30.0);
+	deadline = now_ms() + 2000;
+	while (!have_motion && now_ms() < deadline) {
+		pump(100);
+	}
+	check(have_motion, "no motion after the lock was destroyed");
+	check(fabs(motion_sx - 125.0) < 1.0 && fabs(motion_sy - 80.0) < 1.0,
+	      "cursor-position hint not applied: motion at %.2f,%.2f, expected 125,80", motion_sx, motion_sy);
+
+	/* 5. Confine the pointer (whole surface, so the cursor starts inside),
+	 * then shrink the region to a rectangle that excludes the cursor. The
+	 * compositor must warp the cursor into the new region — to its nearest
+	 * point, half a pixel inside the top-left corner at (300.5, 300.5) —
+	 * or every later relative motion would be clamped to zero and the
+	 * pointer would be wedged. set_region mandates that the warp be
+	 * reported: "If warped, a wl_pointer.motion event will be emitted." */
+	confined_pointer = zwp_pointer_constraints_v1_confine_pointer(constraints, surface, pointer, NULL,
+								      ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+	zwp_confined_pointer_v1_add_listener(confined_pointer, &confined_listener, NULL);
+	deadline = now_ms() + 2000;
+	while (!confined && now_ms() < deadline) {
+		pump(100);
+	}
+	check(confined, "pointer confinement did not activate");
+
+	struct wl_region *region = wl_compositor_create_region(compositor);
+	wl_region_add(region, 300, 300, 100, 100);
+	have_motion = false;
+	zwp_confined_pointer_v1_set_region(confined_pointer, region);
+	wl_region_destroy(region);
+	wl_surface_commit(surface);
+	deadline = now_ms() + 2000;
+	while (!have_motion && now_ms() < deadline) {
+		pump(100);
+	}
+	check(have_motion, "the set_region warp into the shrunken region sent no wl_pointer.motion");
+	check(fabs(motion_sx - 300.5) < 1.0 && fabs(motion_sy - 300.5) < 1.0,
+	      "cursor not warped into the shrunken confine region: motion at %.2f,%.2f, expected 300.5,300.5",
+	      motion_sx, motion_sy);
+
+	/* And the pointer still moves from there, rather than being wedged
+	 * outside the region with every delta clamped to zero. */
+	have_motion = false;
+	inject_relative(5.0, 5.0);
+	deadline = now_ms() + 2000;
+	while (!have_motion && now_ms() < deadline) {
+		pump(100);
+	}
+	check(have_motion, "no motion after the confine region shrank: pointer is wedged");
+	check(fabs(motion_sx - 305.5) < 1.0 && fabs(motion_sy - 305.5) < 1.0,
+	      "motion after the set_region warp did not start from the region: motion at %.2f,%.2f, expected "
+	      "305.5,305.5",
+	      motion_sx, motion_sy);
+
+	/* Absolute motion aimed outside the region is clamped to its edge, not
+	 * dropped: from (305.5, 305.5), a target of (0, 0) slides to the
+	 * region's top-left corner (300, 300). */
+	have_motion = false;
+	inject_absolute(0, 0);
+	deadline = now_ms() + 2000;
+	while (!have_motion && now_ms() < deadline) {
+		pump(100);
+	}
+	check(have_motion, "absolute motion outside the confine region was dropped instead of clamped");
+	check(fabs(motion_sx - 300.0) < 1.0 && fabs(motion_sy - 300.0) < 1.0,
+	      "absolute motion not clamped to the confine region: motion at %.2f,%.2f, expected 300,300", motion_sx,
+	      motion_sy);
+
+	/* 6. Make the effective confine region empty: a constraint region that
+	 * does not intersect the surface's input region. The protocol
+	 * guarantees the pointer is inside the region whenever the confinement
+	 * is active, which an empty region cannot satisfy, so the compositor
+	 * must deactivate the confinement — and then let the pointer move,
+	 * rather than freezing the cursor for as long as the constraint
+	 * lives. */
+	struct wl_region *input_region = wl_compositor_create_region(compositor);
+	wl_region_add(input_region, 0, 0, 400, 400);
+	wl_surface_set_input_region(surface, input_region);
+	wl_region_destroy(input_region);
+	region = wl_compositor_create_region(compositor);
+	wl_region_add(region, 600, 600, 50, 50);
+	zwp_confined_pointer_v1_set_region(confined_pointer, region);
+	wl_region_destroy(region);
+	wl_surface_commit(surface);
+	wl_display_roundtrip(display);
+
+	deadline = now_ms() + 2000;
+	while (confined && now_ms() < deadline) {
+		pump(100);
+	}
+	check(!confined, "confinement not deactivated when its effective region became empty");
+
+	double base_sx = motion_sx;
+	double base_sy = motion_sy;
+	have_motion = false;
+	inject_relative(10.0, 10.0);
+	deadline = now_ms() + 2000;
+	while (!have_motion && now_ms() < deadline) {
+		pump(100);
+	}
+	check(have_motion, "no motion with an empty confine region: pointer is wedged");
+	check(fabs(motion_sx - (base_sx + 10.0)) < 1.0 && fabs(motion_sy - (base_sy + 10.0)) < 1.0,
+	      "motion with an empty confine region was clamped: motion at %.2f,%.2f, expected %.2f,%.2f", motion_sx,
+	      motion_sy, base_sx + 10.0, base_sy + 10.0);
+
+	/* Restoring the input region makes the effective region — the (600,
+	 * 600) rectangle set above — non-empty again: the confinement must
+	 * activate on that commit, warping the pointer into the region to its
+	 * nearest point (600.5, 600.5). The activation warp is not a
+	 * set_region warp and sends no motion event, so observe it through the
+	 * next relative move. */
+	wl_surface_set_input_region(surface, NULL);
+	wl_surface_commit(surface);
+	deadline = now_ms() + 2000;
+	while (!confined && now_ms() < deadline) {
+		pump(100);
+	}
+	check(confined, "confinement not activated again once its region could hold the pointer");
+
+	have_motion = false;
+	inject_relative(5.0, 5.0);
+	deadline = now_ms() + 2000;
+	while (!have_motion && now_ms() < deadline) {
+		pump(100);
+	}
+	check(have_motion, "no motion after the confinement activated again");
+	check(fabs(motion_sx - 605.5) < 1.0 && fabs(motion_sy - 605.5) < 1.0,
+	      "pointer not warped into the region when the confinement activated again: motion at %.2f,%.2f, expected "
+	      "605.5,605.5",
+	      motion_sx, motion_sy);
+
+	zwp_confined_pointer_v1_destroy(confined_pointer);
+	wl_display_roundtrip(display);
+
+	/* 7. Lock with a region that excludes the current cursor position (605.5,
+	 * 605.5): the protocol guarantees the pointer is inside the region
+	 * whenever the lock activates, so the compositor must warp it into the
+	 * region — to its nearest point, (549.5, 549.5) — before pinning. The
+	 * warp sends no motion event; observe it through a relative move after
+	 * unlocking without a hint, which leaves the cursor where it was
+	 * pinned. */
+	locked = false;
+	region = wl_compositor_create_region(compositor);
+	wl_region_add(region, 500, 500, 50, 50);
+	locked_pointer = zwp_pointer_constraints_v1_lock_pointer(constraints, surface, pointer, region,
+								 ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+	wl_region_destroy(region);
+	zwp_locked_pointer_v1_add_listener(locked_pointer, &locked_listener, NULL);
+	deadline = now_ms() + 2000;
+	while (!locked && now_ms() < deadline) {
+		pump(100);
+	}
+	check(locked, "region-restricted pointer lock did not activate");
+
+	/* A lock's region is only the gate its activation passes through — "the
+	 * region where the pointer must be in order for the lock to activate" —
+	 * so committing a region that excludes the pinned position must neither
+	 * warp the pointer nor break the lock. */
+	motion_events = 0;
+	region = wl_compositor_create_region(compositor);
+	wl_region_add(region, 100, 100, 20, 20);
+	zwp_locked_pointer_v1_set_region(locked_pointer, region);
+	wl_region_destroy(region);
+	wl_surface_commit(surface);
+	wl_display_roundtrip(display);
+	check(locked, "a region excluding the pinned position broke the lock");
+	check(motion_events == 0, "a locked pointer was sent motion by set_region (%d motion events)", motion_events);
+
+	zwp_locked_pointer_v1_destroy(locked_pointer);
+	wl_display_roundtrip(display);
+
+	have_motion = false;
+	inject_relative(5.0, 5.0);
+	deadline = now_ms() + 2000;
+	while (!have_motion && now_ms() < deadline) {
+		pump(100);
+	}
+	check(have_motion, "no motion after the region-restricted lock was destroyed");
+	check(fabs(motion_sx - 554.5) < 1.0 && fabs(motion_sy - 554.5) < 1.0,
+	      "lock did not pin the pointer at the point it warped to on activation: motion at %.2f,%.2f, expected "
+	      "554.5,554.5",
+	      motion_sx, motion_sy);
+
+	/* 8. A oneshot lock is deactivated when the pointer focus moves away —
+	 * here, to a second toplevel mapped on top. wlroots destroys a oneshot
+	 * constraint from inside send_deactivated(), so this exercises the
+	 * compositor's reentrant teardown path. The lock also carries a
+	 * cursor-position hint, which must be applied even though the pointer
+	 * focus has already moved on by the time the lock is broken. */
+	locked = false;
+	locked_pointer = zwp_pointer_constraints_v1_lock_pointer(constraints, surface, pointer, NULL,
+								 ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT);
+	zwp_locked_pointer_v1_add_listener(locked_pointer, &locked_listener, NULL);
+	zwp_locked_pointer_v1_set_cursor_position_hint(locked_pointer, wl_fixed_from_int(420), wl_fixed_from_int(210));
+	wl_surface_commit(surface);
+	deadline = now_ms() + 2000;
+	while (!locked && now_ms() < deadline) {
+		pump(100);
+	}
+	check(locked, "oneshot pointer lock did not activate");
+
+	surface2 = wl_compositor_create_surface(compositor);
+	struct xdg_surface *xdg_surface2 = xdg_wm_base_get_xdg_surface(wm_base, surface2);
+	xdg_surface_add_listener(xdg_surface2, &xdg_surface2_listener, NULL);
+	struct xdg_toplevel *toplevel2 = xdg_surface_get_toplevel(xdg_surface2);
+	xdg_toplevel_add_listener(toplevel2, &toplevel_listener, NULL);
+	xdg_toplevel_set_title(toplevel2, "pointer-constraints-test-2");
+	wl_surface_commit(surface2);
+
+	deadline = now_ms() + 5000;
+	while (locked && now_ms() < deadline) {
+		pump(100);
+	}
+	check(!locked, "oneshot lock not deactivated when the focus moved to another toplevel");
+
+	/* The hint must have been applied on deactivation, so a relative move
+	 * of (10, 10) from the hint (420, 210) lands at (430, 220) — observed
+	 * on the second toplevel, which occupies the same layout space. */
+	wl_display_roundtrip(display);
+	have_motion = false;
+	inject_relative(10.0, 10.0);
+	deadline = now_ms() + 2000;
+	while (!have_motion && now_ms() < deadline) {
+		pump(100);
+	}
+	check(have_motion, "no motion after the oneshot lock was broken");
+	check(fabs(motion_sx - 430.0) < 1.0 && fabs(motion_sy - 220.0) < 1.0,
+	      "cursor-position hint not applied on focus-change deactivation: motion at %.2f,%.2f, expected 430,220",
+	      motion_sx, motion_sy);
+
+	/* The compositor already destroyed its side; drop the defunct resource
+	 * and the second toplevel, and verify the compositor survived. */
+	zwp_locked_pointer_v1_destroy(locked_pointer);
+	xdg_toplevel_destroy(toplevel2);
+	xdg_surface_destroy(xdg_surface2);
+	wl_surface_destroy(surface2);
+	check(wl_display_roundtrip(display) != -1, "compositor died deactivating the oneshot lock");
+
+	/* 9. A view that moves under a stationary cursor. Map a small dialog
+	 * (an xdg_toplevel with a parent, which cage centers rather than
+	 * maximizes), confine the pointer on it, then shrink the output mode:
+	 * the dialog is re-centered, changing the cursor's surface-local
+	 * position without moving the cursor. The compositor must resync the
+	 * seat's surface-local position and report it as a wl_pointer.motion;
+	 * a stale position would misdirect every later confinement clamp and
+	 * let the pointer escape the region. The first toplevel's maximized
+	 * size is the output size — the base for all expected coordinates. */
+	int32_t output_width = configured_width;
+	int32_t output_height = configured_height;
+	check(output_width > 400 && output_height > 240, "output too small for the mode-change scenario (%dx%d)",
+	      output_width, output_height);
+
+	surface3 = wl_compositor_create_surface(compositor);
+	struct xdg_surface *xdg_surface3 = xdg_wm_base_get_xdg_surface(wm_base, surface3);
+	xdg_surface_add_listener(xdg_surface3, &xdg_surface3_listener, NULL);
+	struct xdg_toplevel *toplevel3 = xdg_surface_get_toplevel(xdg_surface3);
+	xdg_toplevel_add_listener(toplevel3, &toplevel_listener, NULL);
+	xdg_toplevel_set_title(toplevel3, "pointer-constraints-test-dialog");
+	xdg_toplevel_set_parent(toplevel3, toplevel);
+	wl_surface_commit(surface3);
+
+	deadline = now_ms() + 5000;
+	while (!mapped3 && now_ms() < deadline) {
+		pump(100);
+	}
+	check(mapped3, "the dialog toplevel was not configured");
+	/* Make sure the compositor has processed the mapping commit before
+	 * aiming the cursor at the centered dialog. */
+	wl_display_roundtrip(display);
+
+	/* Move the cursor to the output's center: the dialog's center, at
+	 * surface-local (DIALOG_SIZE / 2, DIALOG_SIZE / 2). */
+	have_enter = false;
+	inject_absolute(5000, 5000);
+	deadline = now_ms() + 2000;
+	while (!have_enter && now_ms() < deadline) {
+		pump(100);
+	}
+	check(have_enter, "cursor did not enter the centered dialog");
+	check(fabs(enter_sx - DIALOG_SIZE / 2) < 1.0 && fabs(enter_sy - DIALOG_SIZE / 2) < 1.0,
+	      "cursor not at the dialog's center: enter at %.2f,%.2f, expected %d,%d", enter_sx, enter_sy,
+	      DIALOG_SIZE / 2, DIALOG_SIZE / 2);
+
+	/* Confine the pointer to a region slightly smaller than the dialog, so
+	 * clamping to the region's edge is observable strictly inside the
+	 * surface. */
+	confined = false;
+	region = wl_compositor_create_region(compositor);
+	wl_region_add(region, 0, 0, DIALOG_SIZE - 10, DIALOG_SIZE - 10);
+	confined_pointer = zwp_pointer_constraints_v1_confine_pointer(constraints, surface3, pointer, region,
+								      ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+	wl_region_destroy(region);
+	zwp_confined_pointer_v1_add_listener(confined_pointer, &confined_listener, NULL);
+	deadline = now_ms() + 2000;
+	while (!confined && now_ms() < deadline) {
+		pump(100);
+	}
+	check(confined, "pointer confinement on the dialog did not activate");
+
+	/* Shrink the output by (160, 80): the re-centered dialog moves by
+	 * (-80, -40), so the stationary cursor's surface-local position moves
+	 * from the center by (+80, +40) — still inside the confine region, so
+	 * no warp is involved. Drain pending zwlr_output_manager_v1.done
+	 * events first; a stale serial would cancel the configuration. */
+	wl_display_roundtrip(display);
+	check(output_head != NULL && output_manager_done, "no zwlr_output_manager_v1 head advertised");
+	struct zwlr_output_configuration_v1 *output_config =
+		zwlr_output_manager_v1_create_configuration(output_manager, output_manager_serial);
+	zwlr_output_configuration_v1_add_listener(output_config, &output_config_listener, NULL);
+	struct zwlr_output_configuration_head_v1 *config_head =
+		zwlr_output_configuration_v1_enable_head(output_config, output_head);
+	zwlr_output_configuration_head_v1_set_custom_mode(config_head, output_width - 160, output_height - 80, 0);
+	have_motion = false;
+	zwlr_output_configuration_v1_apply(output_config);
+	deadline = now_ms() + 5000;
+	while (output_config_result == 0 && now_ms() < deadline) {
+		pump(100);
+	}
+	check(output_config_result == 1, "the output mode change was not applied (%d)", output_config_result);
+	zwlr_output_configuration_v1_destroy(output_config);
+
+	/* The resync must arrive as a motion event, with no input injected. */
+	double moved_sx = DIALOG_SIZE / 2 + 80;
+	double moved_sy = DIALOG_SIZE / 2 + 40;
+	deadline = now_ms() + 2000;
+	while (!have_motion && now_ms() < deadline) {
+		pump(100);
+	}
+	check(have_motion, "no motion after the dialog was re-centered under the stationary cursor");
+	check(fabs(motion_sx - moved_sx) < 1.0 && fabs(motion_sy - moved_sy) < 1.0,
+	      "stale surface-local position after the dialog moved: motion at %.2f,%.2f, expected %.0f,%.0f", motion_sx,
+	      motion_sy, moved_sx, moved_sy);
+
+	/* And confinement clamps from the resynced position: a motion aiming
+	 * past the region's right edge stops at its last row of pixels,
+	 * (DIALOG_SIZE - 11) — from the stale position the same delta would
+	 * have sailed through, taking the pointer out of the region. */
+	have_motion = false;
+	inject_relative(50.0, 0.0);
+	deadline = now_ms() + 2000;
+	while (!have_motion && now_ms() < deadline) {
+		pump(100);
+	}
+	check(have_motion, "no motion after a clamped move inside the confine region");
+	check(fabs(motion_sx - (DIALOG_SIZE - 11)) < 1.0 && fabs(motion_sy - moved_sy) < 1.0,
+	      "confinement clamp did not run from the resynced position: motion at %.2f,%.2f, expected %d,%.0f",
+	      motion_sx, motion_sy, DIALOG_SIZE - 11, moved_sy);
+
+	zwp_confined_pointer_v1_destroy(confined_pointer);
+	xdg_toplevel_destroy(toplevel3);
+	xdg_surface_destroy(xdg_surface3);
+	wl_surface_destroy(surface3);
+	check(wl_display_roundtrip(display) != -1, "compositor died after the mode-change scenario");
+
+	printf("pointer-constraints test passed\n");
+	return 0;
+}

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Runs a test client as cage's application on the headless backend; cage
+# propagates the client's exit code when the client exits.
+#
+# Usage: run-test.sh <cage> <client>
+set -eu
+
+if [ -z "${XDG_RUNTIME_DIR:-}" ] || [ ! -w "${XDG_RUNTIME_DIR:-/nonexistent}" ]; then
+	XDG_RUNTIME_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cage-test.XXXXXX")"
+	export XDG_RUNTIME_DIR
+	trap 'rm -rf "$XDG_RUNTIME_DIR"' EXIT
+fi
+
+export WLR_BACKENDS=headless
+export WLR_RENDERER=pixman
+unset WAYLAND_DISPLAY DISPLAY
+
+# No exec: the EXIT trap above must fire to clean up the temporary runtime
+# dir. set -e propagates a failing exit code.
+"$1" -- "$2"

--- a/tests/wlr-output-management-unstable-v1.xml
+++ b/tests/wlr-output-management-unstable-v1.xml
@@ -1,0 +1,611 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_output_management_unstable_v1">
+  <copyright>
+    Copyright © 2019 Purism SPC
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <description summary="protocol to configure output devices">
+    This protocol exposes interfaces to obtain and modify output device
+    configuration.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_output_manager_v1" version="4">
+    <description summary="output device configuration manager">
+      This interface is a manager that allows reading and writing the current
+      output device configuration.
+
+      Output devices that display pixels (e.g. a physical monitor or a virtual
+      output in a window) are represented as heads. Heads cannot be created nor
+      destroyed by the client, but they can be enabled or disabled and their
+      properties can be changed. Each head may have one or more available modes.
+
+      Whenever a head appears (e.g. a monitor is plugged in), it will be
+      advertised via the head event. Immediately after the output manager is
+      bound, all current heads are advertised.
+
+      Whenever a head's properties change, the relevant wlr_output_head events
+      will be sent. Not all head properties will be sent: only properties that
+      have changed need to.
+
+      Whenever a head disappears (e.g. a monitor is unplugged), a
+      wlr_output_head.finished event will be sent.
+
+      After one or more heads appear, change or disappear, the done event will
+      be sent. It carries a serial which can be used in a create_configuration
+      request to update heads properties.
+
+      The information obtained from this protocol should only be used for output
+      configuration purposes. This protocol is not designed to be a generic
+      output property advertisement protocol for regular clients. Instead,
+      protocols such as xdg-output should be used.
+    </description>
+
+    <event name="head">
+      <description summary="introduce a new head">
+        This event introduces a new head. This happens whenever a new head
+        appears (e.g. a monitor is plugged in) or after the output manager is
+        bound.
+      </description>
+      <arg name="head" type="new_id" interface="zwlr_output_head_v1"/>
+    </event>
+
+    <event name="done">
+      <description summary="sent all information about current configuration">
+        This event is sent after all information has been sent after binding to
+        the output manager object and after any subsequent changes. This applies
+        to child head and mode objects as well. In other words, this event is
+        sent whenever a head or mode is created or destroyed and whenever one of
+        their properties has been changed. Not all state is re-sent each time
+        the current configuration changes: only the actual changes are sent.
+
+        This allows changes to the output configuration to be seen as atomic,
+        even if they happen via multiple events.
+
+        A serial is sent to be used in a future create_configuration request.
+      </description>
+      <arg name="serial" type="uint" summary="current configuration serial"/>
+    </event>
+
+    <request name="create_configuration">
+      <description summary="create a new output configuration object">
+        Create a new output configuration object. This allows to update head
+        properties.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_output_configuration_v1"/>
+      <arg name="serial" type="uint"/>
+    </request>
+
+    <request name="stop">
+      <description summary="stop sending events">
+        Indicates the client no longer wishes to receive events for output
+        configuration changes. However the compositor may emit further events,
+        until the finished event is emitted.
+
+        The client must not send any more requests after this one.
+      </description>
+    </request>
+
+    <event name="finished" type="destructor">
+      <description summary="the compositor has finished with the manager">
+        This event indicates that the compositor is done sending manager events.
+        The compositor will destroy the object immediately after sending this
+        event, so it will become invalid and the client should release any
+        resources associated with it.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="zwlr_output_head_v1" version="4">
+    <description summary="output device">
+      A head is an output device. The difference between a wl_output object and
+      a head is that heads are advertised even if they are turned off. A head
+      object only advertises properties and cannot be used directly to change
+      them.
+
+      A head has some read-only properties: modes, name, description and
+      physical_size. These cannot be changed by clients.
+
+      Other properties can be updated via a wlr_output_configuration object.
+
+      Properties sent via this interface are applied atomically via the
+      wlr_output_manager.done event. No guarantees are made regarding the order
+      in which properties are sent.
+    </description>
+
+    <event name="name">
+      <description summary="head name">
+        This event describes the head name.
+
+        The naming convention is compositor defined, but limited to alphanumeric
+        characters and dashes (-). Each name is unique among all wlr_output_head
+        objects, but if a wlr_output_head object is destroyed the same name may
+        be reused later. The names will also remain consistent across sessions
+        with the same hardware and software configuration.
+
+        Examples of names include 'HDMI-A-1', 'WL-1', 'X11-1', etc. However, do
+        not assume that the name is a reflection of an underlying DRM
+        connector, X11 connection, etc.
+
+        If this head matches a wl_output, the wl_output.name event must report
+        the same name.
+
+        The name event is sent after a wlr_output_head object is created. This
+        event is only sent once per object, and the name does not change over
+        the lifetime of the wlr_output_head object.
+      </description>
+      <arg name="name" type="string"/>
+    </event>
+
+    <event name="description">
+      <description summary="head description">
+        This event describes a human-readable description of the head.
+
+        The description is a UTF-8 string with no convention defined for its
+        contents. Examples might include 'Foocorp 11" Display' or 'Virtual X11
+        output via :1'. However, do not assume that the name is a reflection of
+        the make, model, serial of the underlying DRM connector or the display
+        name of the underlying X11 connection, etc.
+
+        If this head matches a wl_output, the wl_output.description event must
+        report the same name.
+
+        The description event is sent after a wlr_output_head object is created.
+        This event is only sent once per object, and the description does not
+        change over the lifetime of the wlr_output_head object.
+      </description>
+      <arg name="description" type="string"/>
+    </event>
+
+    <event name="physical_size">
+      <description summary="head physical size">
+        This event describes the physical size of the head. This event is only
+        sent if the head has a physical size (e.g. is not a projector or a
+        virtual device).
+
+        The physical size event is sent after a wlr_output_head object is created. This
+        event is only sent once per object, and the physical size does not change over
+        the lifetime of the wlr_output_head object.
+      </description>
+      <arg name="width" type="int" summary="width in millimeters of the output"/>
+      <arg name="height" type="int" summary="height in millimeters of the output"/>
+    </event>
+
+    <event name="mode">
+      <description summary="introduce a mode">
+        This event introduces a mode for this head. It is sent once per
+        supported mode.
+      </description>
+      <arg name="mode" type="new_id" interface="zwlr_output_mode_v1"/>
+    </event>
+
+    <event name="enabled">
+      <description summary="head is enabled or disabled">
+        This event describes whether the head is enabled. A disabled head is not
+        mapped to a region of the global compositor space.
+
+        When a head is disabled, some properties (current_mode, position,
+        transform and scale) are irrelevant.
+      </description>
+      <arg name="enabled" type="int" summary="zero if disabled, non-zero if enabled"/>
+    </event>
+
+    <event name="current_mode">
+      <description summary="current mode">
+        This event describes the mode currently in use for this head. It is only
+        sent if the output is enabled.
+      </description>
+      <arg name="mode" type="object" interface="zwlr_output_mode_v1"/>
+    </event>
+
+    <event name="position">
+      <description summary="current position">
+        This events describes the position of the head in the global compositor
+        space. It is only sent if the output is enabled.
+      </description>
+      <arg name="x" type="int"
+        summary="x position within the global compositor space"/>
+      <arg name="y" type="int"
+        summary="y position within the global compositor space"/>
+    </event>
+
+    <event name="transform">
+      <description summary="current transformation">
+        This event describes the transformation currently applied to the head.
+        It is only sent if the output is enabled.
+      </description>
+      <arg name="transform" type="int" enum="wl_output.transform"/>
+    </event>
+
+    <event name="scale">
+      <description summary="current scale">
+        This events describes the scale of the head in the global compositor
+        space. It is only sent if the output is enabled.
+      </description>
+      <arg name="scale" type="fixed"/>
+    </event>
+
+    <event name="finished">
+      <description summary="the head has disappeared">
+        This event indicates that the head is no longer available. The head
+        object becomes inert. Clients should send a destroy request and release
+        any resources associated with it.
+      </description>
+    </event>
+
+    <!-- Version 2 additions -->
+
+    <event name="make" since="2">
+      <description summary="head manufacturer">
+        This event describes the manufacturer of the head.
+
+        Together with the model and serial_number events the purpose is to
+        allow clients to recognize heads from previous sessions and for example
+        load head-specific configurations back.
+
+        It is not guaranteed this event will be ever sent. A reason for that
+        can be that the compositor does not have information about the make of
+        the head or the definition of a make is not sensible in the current
+        setup, for example in a virtual session. Clients can still try to
+        identify the head by available information from other events but should
+        be aware that there is an increased risk of false positives.
+
+        If sent, the make event is sent after a wlr_output_head object is
+        created and only sent once per object. The make does not change over
+        the lifetime of the wlr_output_head object.
+
+        It is not recommended to display the make string in UI to users. For
+        that the string provided by the description event should be preferred.
+      </description>
+      <arg name="make" type="string"/>
+    </event>
+
+    <event name="model" since="2">
+      <description summary="head model">
+        This event describes the model of the head.
+
+        Together with the make and serial_number events the purpose is to
+        allow clients to recognize heads from previous sessions and for example
+        load head-specific configurations back.
+
+        It is not guaranteed this event will be ever sent. A reason for that
+        can be that the compositor does not have information about the model of
+        the head or the definition of a model is not sensible in the current
+        setup, for example in a virtual session. Clients can still try to
+        identify the head by available information from other events but should
+        be aware that there is an increased risk of false positives.
+
+        If sent, the model event is sent after a wlr_output_head object is
+        created and only sent once per object. The model does not change over
+        the lifetime of the wlr_output_head object.
+
+        It is not recommended to display the model string in UI to users. For
+        that the string provided by the description event should be preferred.
+      </description>
+      <arg name="model" type="string"/>
+    </event>
+
+    <event name="serial_number" since="2">
+      <description summary="head serial number">
+        This event describes the serial number of the head.
+
+        Together with the make and model events the purpose is to allow clients
+        to recognize heads from previous sessions and for example load head-
+        specific configurations back.
+
+        It is not guaranteed this event will be ever sent. A reason for that
+        can be that the compositor does not have information about the serial
+        number of the head or the definition of a serial number is not sensible
+        in the current setup. Clients can still try to identify the head by
+        available information from other events but should be aware that there
+        is an increased risk of false positives.
+
+        If sent, the serial number event is sent after a wlr_output_head object
+        is created and only sent once per object. The serial number does not
+        change over the lifetime of the wlr_output_head object.
+
+        It is not recommended to display the serial_number string in UI to
+        users. For that the string provided by the description event should be
+        preferred.
+      </description>
+      <arg name="serial_number" type="string"/>
+    </event>
+
+    <!-- Version 3 additions -->
+
+    <request name="release" type="destructor" since="3">
+      <description summary="destroy the head object">
+        This request indicates that the client will no longer use this head
+        object.
+      </description>
+    </request>
+
+    <!-- Version 4 additions -->
+
+    <enum name="adaptive_sync_state" since="4">
+      <entry name="disabled" value="0" summary="adaptive sync is disabled"/>
+      <entry name="enabled" value="1" summary="adaptive sync is enabled"/>
+    </enum>
+
+    <event name="adaptive_sync" since="4">
+      <description summary="current adaptive sync state">
+        This event describes whether adaptive sync is currently enabled for
+        the head or not. Adaptive sync is also known as Variable Refresh
+        Rate or VRR.
+      </description>
+      <arg name="state" type="uint" enum="adaptive_sync_state"/>
+    </event>
+  </interface>
+
+  <interface name="zwlr_output_mode_v1" version="3">
+    <description summary="output mode">
+      This object describes an output mode.
+
+      Some heads don't support output modes, in which case modes won't be
+      advertised.
+
+      Properties sent via this interface are applied atomically via the
+      wlr_output_manager.done event. No guarantees are made regarding the order
+      in which properties are sent.
+    </description>
+
+    <event name="size">
+      <description summary="mode size">
+        This event describes the mode size. The size is given in physical
+        hardware units of the output device. This is not necessarily the same as
+        the output size in the global compositor space. For instance, the output
+        may be scaled or transformed.
+      </description>
+      <arg name="width" type="int" summary="width of the mode in hardware units"/>
+      <arg name="height" type="int" summary="height of the mode in hardware units"/>
+    </event>
+
+    <event name="refresh">
+      <description summary="mode refresh rate">
+        This event describes the mode's fixed vertical refresh rate. It is only
+        sent if the mode has a fixed refresh rate.
+      </description>
+      <arg name="refresh" type="int" summary="vertical refresh rate in mHz"/>
+    </event>
+
+    <event name="preferred">
+      <description summary="mode is preferred">
+        This event advertises this mode as preferred.
+      </description>
+    </event>
+
+    <event name="finished">
+      <description summary="the mode has disappeared">
+        This event indicates that the mode is no longer available. The mode
+        object becomes inert. Clients should send a destroy request and release
+        any resources associated with it.
+      </description>
+    </event>
+
+    <!-- Version 3 additions -->
+
+    <request name="release" type="destructor" since="3">
+      <description summary="destroy the mode object">
+        This request indicates that the client will no longer use this mode
+        object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_output_configuration_v1" version="4">
+    <description summary="output configuration">
+      This object is used by the client to describe a full output configuration.
+
+      First, the client needs to setup the output configuration. Each head can
+      be either enabled (and configured) or disabled. It is a protocol error to
+      send two enable_head or disable_head requests with the same head. It is a
+      protocol error to omit a head in a configuration.
+
+      Then, the client can apply or test the configuration. The compositor will
+      then reply with a succeeded, failed or cancelled event. Finally the client
+      should destroy the configuration object.
+    </description>
+
+    <enum name="error">
+      <entry name="already_configured_head" value="1"
+        summary="head has been configured twice"/>
+      <entry name="unconfigured_head" value="2"
+        summary="head has not been configured"/>
+      <entry name="already_used" value="3"
+        summary="request sent after configuration has been applied or tested"/>
+    </enum>
+
+    <request name="enable_head">
+      <description summary="enable and configure a head">
+        Enable a head. This request creates a head configuration object that can
+        be used to change the head's properties.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_output_configuration_head_v1"
+        summary="a new object to configure the head"/>
+      <arg name="head" type="object" interface="zwlr_output_head_v1"
+        summary="the head to be enabled"/>
+    </request>
+
+    <request name="disable_head">
+      <description summary="disable a head">
+        Disable a head.
+      </description>
+      <arg name="head" type="object" interface="zwlr_output_head_v1"
+        summary="the head to be disabled"/>
+    </request>
+
+    <request name="apply">
+      <description summary="apply the configuration">
+        Apply the new output configuration.
+
+        In case the configuration is successfully applied, there is no guarantee
+        that the new output state matches completely the requested
+        configuration. For instance, a compositor might round the scale if it
+        doesn't support fractional scaling.
+
+        After this request has been sent, the compositor must respond with an
+        succeeded, failed or cancelled event. Sending a request that isn't the
+        destructor is a protocol error.
+      </description>
+    </request>
+
+    <request name="test">
+      <description summary="test the configuration">
+        Test the new output configuration. The configuration won't be applied,
+        but will only be validated.
+
+        Even if the compositor succeeds to test a configuration, applying it may
+        fail.
+
+        After this request has been sent, the compositor must respond with an
+        succeeded, failed or cancelled event. Sending a request that isn't the
+        destructor is a protocol error.
+      </description>
+    </request>
+
+    <event name="succeeded">
+      <description summary="configuration changes succeeded">
+        Sent after the compositor has successfully applied the changes or
+        tested them.
+
+        Upon receiving this event, the client should destroy this object.
+
+        If the current configuration has changed, events to describe the changes
+        will be sent followed by a wlr_output_manager.done event.
+      </description>
+    </event>
+
+    <event name="failed">
+      <description summary="configuration changes failed">
+        Sent if the compositor rejects the changes or failed to apply them. The
+        compositor should revert any changes made by the apply request that
+        triggered this event.
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <event name="cancelled">
+      <description summary="configuration has been cancelled">
+        Sent if the compositor cancels the configuration because the state of an
+        output changed and the client has outdated information (e.g. after an
+        output has been hotplugged).
+
+        The client can create a new configuration with a newer serial and try
+        again.
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the output configuration">
+        Using this request a client can tell the compositor that it is not going
+        to use the configuration object anymore. Any changes to the outputs
+        that have not been applied will be discarded.
+
+        This request also destroys wlr_output_configuration_head objects created
+        via this object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_output_configuration_head_v1" version="4">
+    <description summary="head configuration">
+      This object is used by the client to update a single head's configuration.
+
+      It is a protocol error to set the same property twice.
+    </description>
+
+    <enum name="error">
+      <entry name="already_set" value="1" summary="property has already been set"/>
+      <entry name="invalid_mode" value="2" summary="mode doesn't belong to head"/>
+      <entry name="invalid_custom_mode" value="3" summary="mode is invalid"/>
+      <entry name="invalid_transform" value="4" summary="transform value outside enum"/>
+      <entry name="invalid_scale" value="5" summary="scale negative or zero"/>
+      <entry name="invalid_adaptive_sync_state" value="6" since="4"
+        summary="invalid enum value used in the set_adaptive_sync request"/>
+    </enum>
+
+    <request name="set_mode">
+      <description summary="set the mode">
+        This request sets the head's mode.
+      </description>
+      <arg name="mode" type="object" interface="zwlr_output_mode_v1"/>
+    </request>
+
+    <request name="set_custom_mode">
+      <description summary="set a custom mode">
+        This request assigns a custom mode to the head. The size is given in
+        physical hardware units of the output device. If set to zero, the
+        refresh rate is unspecified.
+
+        It is a protocol error to set both a mode and a custom mode.
+      </description>
+      <arg name="width" type="int" summary="width of the mode in hardware units"/>
+      <arg name="height" type="int" summary="height of the mode in hardware units"/>
+      <arg name="refresh" type="int" summary="vertical refresh rate in mHz or zero"/>
+    </request>
+
+    <request name="set_position">
+      <description summary="set the position">
+        This request sets the head's position in the global compositor space.
+      </description>
+      <arg name="x" type="int" summary="x position in the global compositor space"/>
+      <arg name="y" type="int" summary="y position in the global compositor space"/>
+    </request>
+
+    <request name="set_transform">
+      <description summary="set the transform">
+        This request sets the head's transform.
+      </description>
+      <arg name="transform" type="int" enum="wl_output.transform"/>
+    </request>
+
+    <request name="set_scale">
+      <description summary="set the scale">
+        This request sets the head's scale.
+      </description>
+      <arg name="scale" type="fixed"/>
+    </request>
+
+    <!-- Version 4 additions -->
+
+    <request name="set_adaptive_sync" since="4">
+      <description summary="enable/disable adaptive sync">
+        This request enables/disables adaptive sync. Adaptive sync is also
+        known as Variable Refresh Rate or VRR.
+      </description>
+      <arg name="state" type="uint" enum="zwlr_output_head_v1.adaptive_sync_state"/>
+    </request>
+  </interface>
+</protocol>

--- a/tests/wlr-virtual-pointer-unstable-v1.xml
+++ b/tests/wlr-virtual-pointer-unstable-v1.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_virtual_pointer_unstable_v1">
+  <copyright>
+    Copyright © 2019 Josef Gajdusek
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_virtual_pointer_v1" version="2">
+    <description summary="virtual pointer">
+      This protocol allows clients to emulate a physical pointer device. The
+      requests are mostly mirror opposites of those specified in wl_pointer.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_axis" value="0"
+        summary="client sent invalid axis enumeration value" />
+      <entry name="invalid_axis_source" value="1"
+        summary="client sent invalid axis source enumeration value" />
+    </enum>
+
+    <request name="motion">
+      <description summary="pointer relative motion event">
+        The pointer has moved by a relative amount to the previous request.
+
+        Values are in the global compositor space.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="dx" type="fixed" summary="displacement on the x-axis"/>
+      <arg name="dy" type="fixed" summary="displacement on the y-axis"/>
+    </request>
+
+    <request name="motion_absolute">
+      <description summary="pointer absolute motion event">
+        The pointer has moved in an absolute coordinate frame.
+
+        Value of x can range from 0 to x_extent, value of y can range from 0
+        to y_extent.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="x" type="uint" summary="position on the x-axis"/>
+      <arg name="y" type="uint" summary="position on the y-axis"/>
+      <arg name="x_extent" type="uint" summary="extent of the x-axis"/>
+      <arg name="y_extent" type="uint" summary="extent of the y-axis"/>
+    </request>
+
+    <request name="button">
+      <description summary="button event">
+        A button was pressed or released.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="button" type="uint" summary="button that produced the event"/>
+      <arg name="state" type="uint" enum="wl_pointer.button_state" summary="physical state of the button"/>
+    </request>
+
+    <request name="axis">
+      <description summary="axis event">
+        Scroll and other axis requests.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in touchpad coordinates"/>
+    </request>
+
+    <request name="frame">
+      <description summary="end of a pointer event sequence">
+        Indicates the set of events that logically belong together.
+      </description>
+    </request>
+
+    <request name="axis_source">
+      <description summary="axis source event">
+        Source information for scroll and other axis.
+      </description>
+      <arg name="axis_source" type="uint" enum="wl_pointer.axis_source" summary="source of the axis event"/>
+    </request>
+
+    <request name="axis_stop">
+      <description summary="axis stop event">
+        Stop notification for scroll and other axes.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="the axis stopped with this event"/>
+    </request>
+
+    <request name="axis_discrete">
+      <description summary="axis click event">
+        Discrete step information for scroll and other axes.
+
+        This event allows the client to extend data normally sent using the axis
+        event with discrete value.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in touchpad coordinates"/>
+      <arg name="discrete" type="int" summary="number of steps"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual pointer object"/>
+    </request>
+  </interface>
+
+  <interface name="zwlr_virtual_pointer_manager_v1" version="2">
+    <description summary="virtual pointer manager">
+      This object allows clients to create individual virtual pointer objects.
+    </description>
+
+    <request name="create_virtual_pointer">
+      <description summary="Create a new virtual pointer">
+        Creates a new virtual pointer. The optional seat is a suggestion to the
+        compositor.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+      <arg name="id" type="new_id" interface="zwlr_virtual_pointer_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual pointer manager"/>
+    </request>
+
+    <!-- Version 2 additions -->
+    <request name="create_virtual_pointer_with_output" since="2">
+      <description summary="Create a new virtual pointer">
+        Creates a new virtual pointer. The seat and the output arguments are
+        optional. If the seat argument is set, the compositor should assign the
+        input device to the requested seat. If the output argument is set, the
+        compositor should map the input device to the requested output.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="id" type="new_id" interface="zwlr_virtual_pointer_v1"/>
+    </request>
+  </interface>
+</protocol>

--- a/view.c
+++ b/view.c
@@ -110,6 +110,10 @@ view_position_all(struct cg_server *server)
 	wl_list_for_each (view, &server->views, link) {
 		view_position(view);
 	}
+
+	/* The views moved under the cursor: an active pointer constraint has to
+	 * be enforced again from their new positions. */
+	seat_revalidate_pointer_constraint(server->seat);
 }
 
 void


### PR DESCRIPTION
Implements the `zwp_pointer_constraints_v1` protocol, which cage currently lacks. Supersedes #300.

Disclosure: this PR was written by an AI agent (Claude Fable 5, running in Claude Code), driven and reviewed by me. I don't know the maintainers' stance on AI-assisted contributions, so I'd rather say it upfront — happy to withdraw it if that's not welcome here.

## Motivation

Pointer lock and confinement are broken for clients running inside cage today because cage does not implement `zwp_pointer_constraints_v1`:

- **Browsers / WebApps (e.g. Firefox in cage):** The [MDN Pointer Lock demo](https://mdn.github.io/dom-examples/pointer-lock/) doesn't work — the pointer lock "succeeds" at the DOM level, but Firefox has no compositor pointer constraint to lock the actual cursor. Movement deltas continue to be derived from the moving, invisible cursor, which clamps at the display edges. The tracking ball eventually hits an invisible wall and cannot move further in that direction. First-person web games and remote-desktop clients fail the same way.
- **Games & nested compositors (e.g. gamescope):** Clients that lock the pointer and follow `zwp_relative_pointer_v1` (which cage already implements) encounter invisible barriers at drifting offsets from the screen edges, or receive no usable mouse motion at all.

## What it does

The constraint for the pointer-focused surface is enforced according to the Wayland protocol specification:

- **Locked pointers:** Pins the cursor in place. Clients receive unclamped motion events via the `zwp_relative_pointer_v1` stream.
- **Confined pointers:** Motion is clamped to the constraint region using `wlr_region_confine()`, sliding along region boundaries.
- **Cursor position hints on unlock:** On unlock, deactivation, or destruction of the constraint, the cursor warps to the client's `cursor_position_hint` (properly converted from surface-local to layout coordinates), reappearing where the client last rendered its cursor.
- **Dynamic region adjustments & edge cases:**
  - If a confined region shrinks below the cursor position (or a view repositioning leaves the cursor outside), the cursor is warped to the nearest valid point inside the region and emits a `wl_pointer.motion` event per `zwp_confined_pointer_v1.set_region` requirements.
  - If the effective confinement region becomes empty (e.g. constraint region no longer intersects the surface input region), the constraint is deactivated to avoid wedging the pointer, and is re-activated when the region can hold the cursor again.
  - If a lock activates while the cursor is outside the requested region, the cursor warps into the region on activation.
- **Lifecycle & event ordering:**
  - Client constraint activation/deactivation notifications are synchronized via an idle loop (`constraint_sync_idle`) to ensure safe destruction of oneshot constraints (which wlroots destroys synchronously from inside `send_deactivated()`) without disrupting active iteration over surface commits.
  - The relative motion dispatch in `process_cursor_motion()` runs before pointer enter so that entering a surface (which activates its constraint) does not deliver the traversal delta as the first locked relative event.
  - Relative motion synthesized from absolute input devices (e.g. virtual pointers, Wayland/X11 backends) tracks consecutive positions per device while the cursor is pinned, preventing accumulated drift or jumping across devices.

## Relation to #300

#300 stalled in review and targeted wlroots 0.17. This is a clean implementation rebased onto wlroots 0.20 (current master).

## Testing

The second commit adds cage's first automated functional test suite. It is kept lightweight and opt-in via `-Dtests=enabled` (default is `disabled`, so it adds no friction or hard dependencies to default builds), and is integrated into CI.

`meson test` runs cage on the headless backend with pixman rendering, executing a dedicated test client (`tests/pointer-constraints.c`) via `tests/run-test.sh`. The test client drives the compositor from within using `zwlr_virtual_pointer_v1` (protocol XML vendored from wlr-protocols) while a fullscreen toplevel sets up constraints and verifies compositor behavior.

The test verifies:
1. Lock activates when the surface gains pointer focus.
2. Absolute motion while locked produces no `wl_pointer.motion` (cursor remains pinned), while relative deltas continue to flow.
3. Real relative deltas pass through unmodified while locked.
4. Destroying the lock applies the cursor-position hint (e.g., a subsequent relative move lands at `hint + delta`).
5. Shrinking a confined pointer's region warps the cursor into the new region, emits `wl_pointer.motion` as required by `set_region`, and clamps subsequent absolute motion to the region's edge.
6. A confinement whose effective region becomes empty deactivates (allowing the pointer to move freely) and reactivates once the region is restored.
7. Locking with the cursor outside the lock region warps it inside upon activation, while regions committed after activation do not disturb the pinned cursor.
8. Oneshot locks deactivate cleanly when pointer focus shifts to another toplevel (applying the cursor-position hint despite focus loss) and handle compositor-side cleanup safely.

The functional test runs in ~20 ms. Beyond the automated tests, the implementation was verified interactively on the DRM backend with Firefox (MDN Pointer Lock demo tracks indefinitely with no edge clamping) and gamescope.